### PR TITLE
fix writerext and validate utf-8 in get apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "sonic-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrayref",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonic-rs"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Volo Team <volo@cloudwego.io>"]
 edition = "2021"
 description = "Sonic-rs is a fast Rust JSON library based on SIMD"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ More details about optimization can be found in [performance.md](docs/performanc
 
 1. Support x86_64 or aarch64. Note that the performance in aarch64 is lower and needs optimization.
 2. Requires Rust nightly version, as we use the `packed_simd` crate.
-3. When using `get_from`, `get_many`, `JsonIter` or `RawValue`, ***Warn:*** the JSON should be well-formed and valid.
 
 ## Features
 1. Serde into Rust struct as `serde_json` and `serde`.
@@ -47,7 +46,7 @@ To ensure that SIMD instruction is used in sonic-rs, you need to add rustflags `
 Add sonic-rs in `Cargo.toml`
 ```
 [dependencies]
-sonic-rs = 0.2.0
+sonic-rs = 0.2
 ```
 
 ## Benchmark
@@ -395,7 +394,6 @@ By default, sonic-rs does not enable UTF-8 validation. This is a trade-off to ac
 
 - For the `from_slice` and `dom_from_slice` interfaces, validate UTF-8 in default. If users make sure that the json is utf-8 valid, recommended use the `from_slice_unchecked` and `dom_from_slice_unchecked`.
 
-- For the `get` and `lazyvalue` related interfaces, due to the algorithm design, these interfaces are ***only suitable for use in valid-json scenarios***, and we will not provide UTF-8 validation in the future.
 
 ### About floating point precision
 

--- a/README.md
+++ b/README.md
@@ -232,11 +232,11 @@ Sonic-rs utilize SIMD to quickly skip unnecessary fields in the unchecked case, 
 
 ```
 twitter/sonic-rs::get_unchecked_from_str
-                        time:   [67.390 µs 68.121 µs 69.028 µs]
+                        time:   [75.671 µs 76.766 µs 77.894 µs]
 twitter/sonic-rs::get_from_str
-                        time:   [428.33 µs 437.55 µs 448.50 µs]
+                        time:   [430.45 µs 434.62 µs 439.43 µs]
 twitter/gjson::get_from_str
-                        time:   [348.30 µs 355.34 µs 364.13 µs]
+                        time:   [359.61 µs 363.14 µs 367.19 µs]
 ```
 
 ## Usage

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -232,11 +232,11 @@ citm_catalog/serde_json::to_string
 
 ```
 twitter/sonic-rs::get_unchecked_from_str
-                        time:   [67.390 µs 68.121 µs 69.028 µs]
+                        time:   [75.671 µs 76.766 µs 77.894 µs]
 twitter/sonic-rs::get_from_str
-                        time:   [428.33 µs 437.55 µs 448.50 µs]
+                        time:   [430.45 µs 434.62 µs 439.43 µs]
 twitter/gjson::get_from_str
-                        time:   [348.30 µs 355.34 µs 364.13 µs]
+                        time:   [359.61 µs 363.14 µs 367.19 µs]
 ```
 
 ## 用法

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -25,7 +25,6 @@ sonic-rs 的主要优化是使用 SIMD。然而，sonic-rs 没有使用来自`si
 
 1. 支持 x86_64 或 aarch64，aarch64 的性能较低，需要优化。
 2. 需要 Rust nightly 版本，因为 sonic-rs 使用了 `packed_simd` 包。
-3. 使用 `get_from`、`get_many`、`JsonIter` 或 `RawValue` 时，JSON 应该是格式正确且有效的。
 
 ## 功能
 
@@ -43,7 +42,7 @@ sonic-rs 的主要优化是使用 SIMD。然而，sonic-rs 没有使用来自`si
 在 Cargo 依赖中添加 sonic-rs:
 ```
 [dependencies]
-sonic-rs = 0.2.0
+sonic-rs = 0.2
 ```
 
 
@@ -392,8 +391,6 @@ fn main() {
 sonic-rs 默认并不开启 utf-8 校验，这是为了性能做出的权衡。
 
 - 对于 `from_slice` 和 `dom_from_slice` 接口，默认开启了 `utf8` 校验。如果用户确保是 `utf-8`, 也可以使用 `from_slice_unchecked` 和 `dom_from_slice_unchecked`。
-
-- 对于 `get` 和 `lazyvaue` 相关接口，由于实现算法设计的原因，这些接口***只适合在 valid-json 场景下使用***，我们后续也不会提供 utf-8 校验。
 
 ### 关于浮点数精度
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -60,6 +60,7 @@ impl<'de> AsRef<[u8]> for JsonSlice<'de> {
 }
 
 pub trait JsonInput<'de>: Sealed {
+    fn need_utf8_valid(&self) -> bool;
     fn to_json_slice(&self) -> JsonSlice<'de>;
     #[allow(clippy::wrong_self_convention)]
     fn from_subset(&self, sub: &'de [u8]) -> JsonSlice<'de>;
@@ -67,6 +68,10 @@ pub trait JsonInput<'de>: Sealed {
 }
 
 impl<'de> JsonInput<'de> for &'de [u8] {
+    fn need_utf8_valid(&self) -> bool {
+        true
+    }
+
     fn to_json_slice(&self) -> JsonSlice<'de> {
         JsonSlice::Raw(self)
     }
@@ -81,6 +86,9 @@ impl<'de> JsonInput<'de> for &'de [u8] {
 }
 
 impl<'de> JsonInput<'de> for &'de str {
+    fn need_utf8_valid(&self) -> bool {
+        false
+    }
     fn to_json_slice(&self) -> JsonSlice<'de> {
         JsonSlice::Raw((*self).as_bytes())
     }
@@ -95,6 +103,10 @@ impl<'de> JsonInput<'de> for &'de str {
 }
 
 impl<'de> JsonInput<'de> for &'de Bytes {
+    fn need_utf8_valid(&self) -> bool {
+        true
+    }
+
     fn to_json_slice(&self) -> JsonSlice<'de> {
         let bytes = self.as_ref();
         let newed = self.slice_ref(bytes);
@@ -111,6 +123,10 @@ impl<'de> JsonInput<'de> for &'de Bytes {
 }
 
 impl<'de> JsonInput<'de> for &'de FastStr {
+    fn need_utf8_valid(&self) -> bool {
+        false
+    }
+
     fn to_json_slice(&self) -> JsonSlice<'de> {
         JsonSlice::FastStr((**self).clone())
     }
@@ -125,6 +141,10 @@ impl<'de> JsonInput<'de> for &'de FastStr {
 }
 
 impl<'de> JsonInput<'de> for &'de String {
+    fn need_utf8_valid(&self) -> bool {
+        false
+    }
+
     fn to_json_slice(&self) -> JsonSlice<'de> {
         JsonSlice::Raw(self.as_bytes())
     }

--- a/src/lazyvalue/get.rs
+++ b/src/lazyvalue/get.rs
@@ -3,11 +3,11 @@ use crate::error::Result;
 use crate::input::JsonInput;
 use crate::parser::Parser;
 use crate::pointer::{PointerTrait, PointerTree};
+use crate::reader::Reader;
 use crate::reader::SliceRead;
+use crate::util::utf8::from_utf8;
 use bytes::Bytes;
 use faststr::FastStr;
-use crate::reader::Reader;
-use crate::util::utf8::from_utf8;
 
 /// get_from_str_unchecked returns the raw value from path.
 ///
@@ -177,9 +177,9 @@ where
     let mut parser = Parser::new(reader);
     let out = parser.get_many(tree, true)?;
     let nodes = out
-    .into_iter()
-    .map(|subset| LazyValue::new(json.from_subset(subset)))
-    .collect();
+        .into_iter()
+        .map(|subset| LazyValue::new(json.from_subset(subset)))
+        .collect();
 
     // validate the utf-8 if slice
     let index = parser.read.index();
@@ -193,7 +193,7 @@ where
 mod test {
     use super::*;
     use crate::{pointer, JsonPointer, PointerNode};
-    use std::str::{FromStr, from_utf8_unchecked};
+    use std::str::{from_utf8_unchecked, FromStr};
 
     #[test]
     fn test_get_from_json() {
@@ -269,7 +269,7 @@ mod test {
             assert!(out.is_err(), "json is {:?}", json);
 
             // test for SIMD codes
-            let json =  unsafe { from_utf8_unchecked(json) }.to_string() + &" ".repeat(1000);
+            let json = unsafe { from_utf8_unchecked(json) }.to_string() + &" ".repeat(1000);
             let out = get_from_slice(json.as_bytes(), path);
             assert!(out.is_err());
         }

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -68,7 +68,7 @@ impl<'de> JsonValue for LazyValue<'de> {
         }
     }
 
-    fn get<I: crate::Index>(&self, index: I) -> Option<Self::ValueType<'_>> {
+    fn get<I: crate::value::Index>(&self, index: I) -> Option<Self::ValueType<'_>> {
         index.lazyvalue_index_into(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,32 @@ pub mod value;
 pub mod visitor;
 pub mod writer;
 
-pub use crate::error::*;
-pub use crate::pointer::*;
+#[doc(inline)]
+pub use crate::error::{Error, Result};
 
-pub use crate::lazyvalue::*;
-pub use crate::serde::*;
-pub use crate::value::*;
+#[doc(inline)]
+pub use crate::lazyvalue::{
+    get, get_from_bytes, get_from_bytes_unchecked, get_from_faststr, get_from_faststr_unchecked,
+    get_from_slice, get_from_slice_unchecked, get_from_str, get_from_str_unchecked, get_many,
+    get_many_unchecked, get_unchecked, to_array_iter, to_object_iter, ArrayIntoIter, LazyValue,
+    ObjectIntoIter,
+};
+
+#[doc(inline)]
+pub use crate::pointer::{JsonPointer, PointerNode, PointerTrait, PointerTree};
+
+#[doc(inline)]
+pub use crate::serde::{
+    from_slice, from_slice_unchecked, from_str, to_raw_value, to_string, to_string_pretty, to_vec,
+    to_vec_pretty, to_writer, to_writer_pretty, Deserializer, JsonNumberTrait, Number, RawNumber,
+    RawValue, Serializer,
+};
+
+#[doc(inline)]
+pub use crate::value::{
+    dom_from_slice, dom_from_slice_unchecked, dom_from_str, Array, ArrayMut, Document, JsonType,
+    JsonValue, Object, ObjectMut, Value, ValueMut,
+};
+
+// re-export the serde trait
+pub use ::serde::{Deserialize, Serialize};

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -12,9 +12,6 @@ pub use self::ser::{
 
 pub(crate) use self::de::tri;
 
-// re-export serde trait
-pub use serde::{Deserialize, Serialize};
-
 #[cfg(test)]
 #[allow(clippy::mutable_key_type)]
 mod test {

--- a/src/serde/number.rs
+++ b/src/serde/number.rs
@@ -59,6 +59,7 @@ impl Hash for N {
     }
 }
 
+/// Number trait for both `Number` and `RawNumber`.
 pub trait JsonNumberTrait: Sealed {
     fn is_i64(&self) -> bool;
     fn is_u64(&self) -> bool;

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -31,8 +31,8 @@ impl StringBlock {
     #[inline(always)]
     pub fn find(ptr: *const u8) -> Self {
         let v = unsafe {
-            let chunck = from_raw_parts(ptr, Self::LANS);
-            u8x32::from_slice_unaligned_unchecked(chunck)
+            let chunk = from_raw_parts(ptr, Self::LANS);
+            u8x32::from_slice_unaligned_unchecked(chunk)
         };
         let bs_bits = (v.eq(u8x32::splat(b'\\'))).bitmask();
         let quote_bits = (v.eq(u8x32::splat(b'"'))).bitmask();
@@ -127,8 +127,8 @@ pub(crate) unsafe fn parse_string_inplace(
         'find_and_move: loop {
             let v = unsafe {
                 let ptr = *src;
-                let chunck = from_raw_parts(ptr, LANS);
-                u8x32::from_slice_unaligned_unchecked(chunck)
+                let chunk = from_raw_parts(ptr, LANS);
+                u8x32::from_slice_unaligned_unchecked(chunk)
             };
             let block = StringBlock {
                 bs_bits: (v.eq(u8x32::splat(b'\\'))).bitmask(),
@@ -148,8 +148,8 @@ pub(crate) unsafe fn parse_string_inplace(
                 return Err(ControlCharacterWhileParsingString);
             }
             if !block.has_backslash() {
-                let chunck = from_raw_parts_mut(dst, LANS);
-                v.write_to_slice_unaligned_unchecked(chunck);
+                let chunk = from_raw_parts_mut(dst, LANS);
+                v.write_to_slice_unaligned_unchecked(chunk);
                 *src = src.add(LANS);
                 dst = dst.add(LANS);
                 continue 'find_and_move;
@@ -180,8 +180,8 @@ pub(crate) unsafe fn parse_string_unchecked(
         'find_and_move: loop {
             let v = unsafe {
                 let ptr = *src;
-                let chunck = from_raw_parts(ptr, LANS);
-                u8x32::from_slice_unaligned_unchecked(chunck)
+                let chunk = from_raw_parts(ptr, LANS);
+                u8x32::from_slice_unaligned_unchecked(chunk)
             };
             let block = StringBlock {
                 bs_bits: (v.eq(u8x32::splat(b'\\'))).bitmask(),
@@ -201,8 +201,8 @@ pub(crate) unsafe fn parse_string_unchecked(
                 return Err(ControlCharacterWhileParsingString);
             }
             if !block.has_backslash() {
-                let chunck = from_raw_parts_mut(dst, LANS);
-                v.write_to_slice_unaligned_unchecked(chunck);
+                let chunk = from_raw_parts_mut(dst, LANS);
+                v.write_to_slice_unaligned_unchecked(chunk);
                 *src = src.add(LANS);
                 dst = dst.add(LANS);
                 continue 'find_and_move;

--- a/src/util/utf8.rs
+++ b/src/util/utf8.rs
@@ -1,6 +1,7 @@
-use crate::Error;
-use crate::ErrorCode;
-use crate::{error::Result, reader::Position};
+use crate::{
+    error::{Error, ErrorCode, Result},
+    reader::Position,
+};
 
 #[inline(always)]
 pub(crate) fn from_utf8(data: &[u8]) -> Result<&str> {

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,4 +1,4 @@
-use crate::{value::Value, LazyValue};
+use crate::{lazyvalue::LazyValue, value::Value};
 use core::ops;
 
 pub trait Index: private::Sealed {

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1,13 +1,14 @@
 use super::value_trait::{JsonType, JsonValue};
+use super::Index;
+use super::IndexMut;
 use crate::error::Result;
 use crate::parser::Parser;
 use crate::pointer::{JsonPointer, PointerNode};
 use crate::reader::UncheckedSliceRead;
 use crate::serde::tri;
 use crate::util::utf8::from_utf8;
-use crate::value::Index;
 use crate::visitor::JsonVisitor;
-use crate::{to_string, IndexMut, Number};
+use crate::{to_string, Number};
 use bumpalo::Bump;
 use core::mem::size_of;
 use serde::ser::{Error, Serialize, SerializeMap, SerializeSeq};

--- a/src/value/value_trait.rs
+++ b/src/value/value_trait.rs
@@ -1,4 +1,4 @@
-use crate::{Index, JsonNumberTrait, JsonPointer, Number};
+use crate::{value::Index, JsonNumberTrait, JsonPointer, Number};
 
 /// JsonType is an enum that represents the type of a JSON value.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,7 +6,7 @@ use std::slice::from_raw_parts_mut;
 use std::mem::MaybeUninit;
 
 /// WriterExt is a extension to write with reserved space. It is designed for
-/// SIMD serializing without bound-checking. 
+/// SIMD serializing without bound-checking.
 pub trait WriterExt: io::Write {
     /// rerserve with additional space, equal as vector/bufmut reserve, but return the reserved buffer at [len: cap]
     /// # Safety
@@ -71,7 +71,7 @@ impl<W: WriterExt + ?Sized> WriterExt for Box<W> {
 
 #[cfg(test)]
 mod test {
-    use bytes::{BytesMut, BufMut};
+    use bytes::{BufMut, BytesMut};
 
     use crate::writer::WriterExt;
     use std::io::Write;
@@ -79,7 +79,7 @@ mod test {
     #[test]
     fn test_writer() {
         let buffer = BytesMut::new();
-        let writer =  &mut buffer.writer();
+        let writer = &mut buffer.writer();
 
         let buf = unsafe { writer.reserve_with(20) }.unwrap_or_default();
         assert_eq!(buf.len(), 20);


### PR DESCRIPTION
Refactor the writerext trait to support `&mut T`. Fixed  #26 