### PR TITLE
refactor and optimize document parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         cargo test
         cargo install cargo-fuzz
         cargo +nightly fuzz run fuzz_value -- -max_total_time=5m
+        ./scripts/test.sh
 
 
   test-linux-aarch64:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed220d76ae44c7c94341d8082b26c296de76568b814525fe5ea4fe5737e9f76b"
+checksum = "e5a3720326b20bf5b95b72dbbd133caae7e0dcf71eae8f6e6656e71a7e5c9aaa"
 dependencies = [
  "getrandom",
  "halfbrown",
@@ -892,7 +892,6 @@ dependencies = [
  "simd-json",
  "simdutf8",
  "smallvec",
- "static_assertions",
  "thiserror",
 ]
 
@@ -1161,18 +1160,18 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,13 +4,14 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -60,6 +61,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -513,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
@@ -528,6 +535,16 @@ name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -590,6 +607,29 @@ checksum = "1f9f08af0c877571712e2e3e686ad79efad9657dbf0f7c3c8ba943ff6c38932d"
 dependencies = [
  "cfg-if",
  "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
 ]
 
 [[package]]
@@ -665,6 +705,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,7 +768,7 @@ version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -831,7 +880,9 @@ dependencies = [
  "itoa",
  "jemallocator",
  "json-benchmark",
+ "libc",
  "packed_simd",
+ "parking_lot",
  "paste",
  "ryu",
  "serde",
@@ -841,6 +892,7 @@ dependencies = [
  "simd-json",
  "simdutf8",
  "smallvec",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -1106,3 +1158,23 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,7 @@ bytes = "1.4"
 thiserror = "1.0"
 simdutf8 = "0.1"
 parking_lot = "0.12"
-static_assertions = "1.1"
-libc = "0.2.150"
+libc = "0.2"
 
 [dev-dependencies]
 jemallocator =  "0.5"
@@ -57,10 +56,6 @@ codegen-units = 1
 panic = 'unwind'
 incremental = false
 overflow-checks = false
-
-[build]
-sanitizers = true
-debug = true
 
 [[bench]]
 name = "deserialize_struct"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ bumpalo = "3.13"
 bytes = "1.4"
 thiserror = "1.0"
 simdutf8 = "0.1"
+parking_lot = "0.12"
+static_assertions = "1.1"
+libc = "0.2.150"
 
 [dev-dependencies]
 jemallocator =  "0.5"
@@ -54,6 +57,10 @@ codegen-units = 1
 panic = 'unwind'
 incremental = false
 overflow-checks = false
+
+[build]
+sanitizers = true
+debug = true
 
 [[bench]]
 name = "deserialize_struct"

--- a/benches/deserialize_value.rs
+++ b/benches/deserialize_value.rs
@@ -35,17 +35,17 @@ fn sonic_rs_from_slice_unchecked(data: &[u8]) {
     let _: sonic_rs::Value = unsafe { sonic_rs::from_slice_unchecked(data).unwrap() };
 }
 
-fn sonic_rs_skip_one(data: &[u8]) {
-    unsafe {
-        let data = from_utf8_unchecked(data);
-        let empty: &[&str] = &[];
-        let _ = sonic_rs::get_unchecked(data, empty).unwrap();
-    }
-}
+// fn sonic_rs_skip_one(data: &[u8]) {
+//     unsafe {
+//         let data = from_utf8_unchecked(data);
+//         let empty: &[&str] = &[];
+//         let _ = sonic_rs::get_unchecked(data, empty).unwrap();
+//     }
+// }
 
-fn sonic_rs_to_serdejson_value(data: &[u8]) {
-    let _: serde_json::Value = sonic_rs::from_slice(data).unwrap();
-}
+// fn sonic_rs_to_serdejson_value(data: &[u8]) {
+//     let _: serde_json::Value = sonic_rs::from_slice(data).unwrap();
+// }
 
 macro_rules! bench_file {
     ($name:ident) => {
@@ -88,21 +88,21 @@ macro_rules! bench_file {
                 )
             });
 
-            group.bench_with_input("sonic_rs::skip_one", &vec, |b, data| {
-                b.iter_batched(
-                    || data,
-                    |bytes| sonic_rs_skip_one(&bytes),
-                    BatchSize::SmallInput,
-                )
-            });
+            // group.bench_with_input("sonic_rs::skip_one", &vec, |b, data| {
+            //     b.iter_batched(
+            //         || data,
+            //         |bytes| sonic_rs_skip_one(&bytes),
+            //         BatchSize::SmallInput,
+            //     )
+            // });
 
-            group.bench_with_input("sonic_rs::to_serdejson_value", &vec, |b, data| {
-                b.iter_batched(
-                    || data,
-                    |bytes| sonic_rs_to_serdejson_value(&bytes),
-                    BatchSize::SmallInput,
-                )
-            });
+            // group.bench_with_input("sonic_rs::to_serdejson_value", &vec, |b, data| {
+            //     b.iter_batched(
+            //         || data,
+            //         |bytes| sonic_rs_to_serdejson_value(&bytes),
+            //         BatchSize::SmallInput,
+            //     )
+            // });
 
             group.bench_with_input("serde_json::from_slice", &vec, |b, data| {
                 b.iter_batched(

--- a/benches/serialize_value.rs
+++ b/benches/serialize_value.rs
@@ -17,7 +17,7 @@ fn serde_to_string(val: &serde_json::Value) {
     let _ = serde_json::to_string(val).unwrap();
 }
 
-fn sonic_rs_to_string(val: &sonic_rs::value::Document) {
+fn sonic_rs_to_string(val: &sonic_rs::Value) {
     let _ = sonic_rs::to_string(val).unwrap();
 }
 
@@ -60,7 +60,7 @@ macro_rules! bench_file {
                 let serde_out: serde_json::Value = serde_json::from_slice(&data).unwrap();
                 let expect = serde_json::to_string(&serde_out).unwrap();
 
-                let value = sonic_rs::value::dom_from_slice(&data).unwrap();
+                let value: sonic_rs::Value = sonic_rs::from_slice(&data).unwrap();
                 let got = sonic_rs::to_string(&value).unwrap();
                 assert!(
                     diff_json(&got, &expect),
@@ -71,7 +71,7 @@ macro_rules! bench_file {
             let mut group = c.benchmark_group(stringify!($name));
             group.sampling_mode(SamplingMode::Flat);
 
-            let value = sonic_rs::value::dom_from_slice(&data).unwrap();
+            let value: sonic_rs::Value = sonic_rs::from_slice(&data).unwrap();
             group.bench_with_input("sonic_rs::to_string", &value, |b, data| {
                 b.iter_batched(
                     || data,

--- a/examples/document.rs
+++ b/examples/document.rs
@@ -1,8 +1,10 @@
 // Parse json into sonic_rs document.
 
-use sonic_rs::value::{dom_from_slice, Value};
-use sonic_rs::PointerNode;
-use sonic_rs::{pointer, JsonValue};
+use serde_json::json;
+use sonic_rs::from_str;
+use sonic_rs::JsonValueMutTrait;
+use sonic_rs::{pointer, JsonValueTrait, Value};
+
 fn main() {
     let json = r#"{
         "name": "Xiaoming",
@@ -17,9 +19,7 @@ fn main() {
         ]
     }"#;
 
-    let mut dom = dom_from_slice(json.as_bytes()).unwrap();
-    // get the value from dom
-    let root = dom.as_value();
+    let mut root: Value = from_str(json).unwrap();
 
     // get key from value
     let age = root.get("age").as_i64();
@@ -34,8 +34,17 @@ fn main() {
     assert_eq!(phones.as_str().unwrap(), "+123456");
 
     // convert to mutable object
-    let mut obj = dom.as_object_mut().unwrap();
-    let value = Value::new_bool(true);
-    obj.insert("inserted", value);
-    assert!(obj.contains_key("inserted"));
+    let obj = root.as_object_mut().unwrap();
+    obj.insert(&"inserted", true);
+    assert!(obj.contains_key(&"inserted"));
+
+    let mut object = json!({ "A": 65, "B": 66, "C": 67 });
+    *object.get_mut("A").unwrap() = json!({
+        "code": 123,
+        "success": false,
+        "payload": {}
+    });
+
+    let mut array = json!(["A", "B", "C"]);
+    *array.get_mut(2).unwrap() = json!("D");
 }

--- a/examples/get_from.rs
+++ b/examples/get_from.rs
@@ -1,4 +1,5 @@
-use sonic_rs::{get, get_unchecked, pointer, JsonValue, PointerNode};
+use sonic_rs::JsonValueTrait;
+use sonic_rs::{get, get_unchecked, pointer};
 
 fn main() {
     let path = pointer!["a", "b", "c", 1];

--- a/examples/get_many.rs
+++ b/examples/get_many.rs
@@ -1,5 +1,4 @@
 use sonic_rs::pointer;
-use sonic_rs::PointerNode;
 
 fn main() {
     let json = r#"

--- a/examples/iterator.rs
+++ b/examples/iterator.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 use faststr::FastStr;
-use sonic_rs::{to_array_iter, to_object_iter_unchecked, JsonValue};
-
+use sonic_rs::JsonValueTrait;
+use sonic_rs::{to_array_iter, to_object_iter_unchecked};
 fn main() {
     let json = Bytes::from(r#"[1, 2, 3, 4, 5, 6]"#);
     let iter = to_array_iter(&json);

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -1,8 +1,7 @@
-// Parse json into sonic_rs document.
+// Parse json into sonic_rs `Value`.
 
-use serde_json::json;
-use sonic_rs::from_str;
 use sonic_rs::JsonValueMutTrait;
+use sonic_rs::{from_str, json};
 use sonic_rs::{pointer, JsonValueTrait, Value};
 
 fn main() {
@@ -45,6 +44,9 @@ fn main() {
         "payload": {}
     });
 
-    let mut array = json!(["A", "B", "C"]);
-    *array.get_mut(2).unwrap() = json!("D");
+    let mut val = json!(["A", "B", "C"]);
+    *val.get_mut(2).unwrap() = json!("D");
+
+    // serialize
+    assert_eq!(serde_json::to_string(&val).unwrap(), r#"["A","B","D"]"#);
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -21,6 +21,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -95,6 +101,16 @@ name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "num-traits"
@@ -123,6 +139,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,10 +180,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -199,11 +253,14 @@ dependencies = [
  "cfg-if",
  "faststr",
  "itoa",
+ "libc",
  "packed_simd",
+ "parking_lot",
  "ryu",
  "serde",
  "simdutf8",
  "smallvec",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -217,6 +274,12 @@ dependencies = [
  "serde_json",
  "sonic-rs",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -254,3 +317,60 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -260,7 +260,6 @@ dependencies = [
  "serde",
  "simdutf8",
  "smallvec",
- "static_assertions",
  "thiserror",
 ]
 
@@ -274,12 +273,6 @@ dependencies = [
  "serde_json",
  "sonic-rs",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -ex
+
+export ASAN_OPTIONS="disable_coredump=0:unmap_shadow_on_exit=1:abort_on_error=1"
+
+testcase_lists() {
+	cargo test -- -Zunstable-options --list --format json | jq -c 'select(.type=="test") | .name' | awk -F'"' '{print $2}' | awk '{print ($2) ? $3 : $1}'
+	return $?
+}
+
+sanitize() {
+	SAN=$1
+	TARGET=$2
+	TESTCASE=$3
+	echo "Running tests with $SAN on $TARGET"
+	# # use single thread to make error info more readable and accurate
+	RUSTFLAGS="-Zsanitizer=$SAN" RUSTDOCFLAGS="-Zsanitizer=$SAN" cargo test --target $TARGET $3 -- --test-threads=1
+}
+
+sanitize_single() {
+	SAN=$1
+	TARGET=$2
+	for CASE in $(testcase_lists); do
+		sanitize $SAN $TARGET $CASE
+	done
+}
+
+for san in address leak; do
+	echo "Running tests with $san"
+	# sanitize $san "x86_64-unknown-linux-gnu"
+    sanitize_single $san "x86_64-unknown-linux-gnu"
+done

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,6 +28,6 @@ sanitize_single() {
 
 for san in address leak; do
 	echo "Running tests with $san"
-	# sanitize $san "x86_64-unknown-linux-gnu"
-    sanitize_single $san "x86_64-unknown-linux-gnu"
+	sanitize $san "x86_64-unknown-linux-gnu"
+    # sanitize_single $san "x86_64-unknown-linux-gnu"
 done

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,10 @@ impl Error {
             | ErrorCode::ExpectedArrayStart
             | ErrorCode::ExpectedObjectStart
             | ErrorCode::InvalidSurrogateUnicodeCodePoint
+            | ErrorCode::ValueKeyMustBeString
+            | ErrorCode::FloatMustBeFinite
+            | ErrorCode::ExpectedQuote
+            | ErrorCode::ExpectedNumericKey
             | ErrorCode::RecursionLimitExceeded => Category::Syntax,
         }
     }
@@ -256,6 +260,17 @@ pub(crate) enum ErrorCode {
 
     #[error("Invalid surrogate Unicode code point")]
     InvalidSurrogateUnicodeCodePoint,
+    #[error("JSON `Value` key must be string")]
+    ValueKeyMustBeString,
+
+    #[error("Float must be finite")]
+    FloatMustBeFinite,
+
+    #[error("Expect a numeric key in Value")]
+    ExpectedNumericKey,
+
+    #[error("Expect a quote")]
+    ExpectedQuote,
 }
 
 impl Error {
@@ -467,8 +482,6 @@ fn starts_with_digit(slice: &str) -> bool {
 
 #[cfg(test)]
 mod test {
-
-    use crate::Value;
     use crate::{from_slice, from_str, Deserialize};
 
     #[test]
@@ -548,8 +561,8 @@ mod test {
     }
 
     #[test]
-    fn test_other_erros() {
-        let err = Value::try_from(f64::NAN).unwrap_err();
+    fn test_other_errors() {
+        let err = crate::Value::try_from(f64::NAN).unwrap_err();
         assert_eq!(
             format!("{}", err),
             "NaN or Infinity is not a valid JSON value"

--- a/src/error.rs
+++ b/src/error.rs
@@ -263,7 +263,7 @@ pub(crate) enum ErrorCode {
     #[error("JSON `Value` key must be string")]
     ValueKeyMustBeString,
 
-    #[error("Float must be finite")]
+    #[error("Float number must be finite, not be Infinity or NaN")]
     FloatMustBeFinite,
 
     #[error("Expect a numeric key in Value")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,11 +11,6 @@ pub enum JsonSlice<'de> {
     FastStr(FastStr),
 }
 
-pub struct RawValue2<'de> {
-    json: &'de str,
-    json2: FastStr,
-}
-
 impl<'de> JsonSlice<'de> {
     pub fn slice_ref(&self, subset: &'de [u8]) -> Self {
         match self {

--- a/src/input.rs
+++ b/src/input.rs
@@ -11,6 +11,11 @@ pub enum JsonSlice<'de> {
     FastStr(FastStr),
 }
 
+pub struct RawValue2<'de> {
+    json: &'de str,
+    json2: FastStr,
+}
+
 impl<'de> JsonSlice<'de> {
     pub fn slice_ref(&self, subset: &'de [u8]) -> Self {
         match self {

--- a/src/lazyvalue/from.rs
+++ b/src/lazyvalue/from.rs
@@ -1,0 +1,9 @@
+use crate::LazyValue;
+use crate::RawValue;
+
+impl<'de> From<&'de RawValue> for LazyValue<'de> {
+    #[inline]
+    fn from(raw: &'de RawValue) -> Self {
+        Self::new(raw.as_ref().into())
+    }
+}

--- a/src/lazyvalue/get.rs
+++ b/src/lazyvalue/get.rs
@@ -192,7 +192,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{pointer, JsonPointer, PointerNode};
+    use crate::{pointer, JsonPointer};
     use std::str::{from_utf8_unchecked, FromStr};
 
     #[test]

--- a/src/lazyvalue/iterator.rs
+++ b/src/lazyvalue/iterator.rs
@@ -185,7 +185,7 @@ impl<'de> Iterator for UnsafeArrayIntoIter<'de> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{value::JsonValue, JsonType};
+    use crate::{value::JsonValueTrait, JsonType};
     use bytes::Bytes;
 
     #[test]

--- a/src/lazyvalue/mod.rs
+++ b/src/lazyvalue/mod.rs
@@ -1,3 +1,4 @@
+mod from;
 mod get;
 mod iterator;
 mod value;

--- a/src/lazyvalue/mod.rs
+++ b/src/lazyvalue/mod.rs
@@ -10,7 +10,7 @@ pub use get::{
 };
 pub use iterator::{
     to_array_iter, to_array_iter_unchecked, to_object_iter, to_object_iter_unchecked,
-    ArrayIntoIter, ObjectIntoIter, UnsafeArrayIntoIter, UnsafeObjectIntoIter,
+    ArrayJsonIter, ObjectJsonIter, UnsafeArrayJsonIter, UnsafeObjectJsonIter,
 };
 pub use value::LazyValue;
 

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -15,8 +15,9 @@ use crate::reader::Reference;
 use crate::reader::SliceRead;
 use crate::serde::Deserializer;
 use crate::serde::Number;
+use crate::value::index::Index;
 use crate::JsonType;
-use crate::{from_str, JsonValue};
+use crate::{from_str, JsonValueTrait};
 
 /// LazyValue is a raw value from json text. Mainly used for get few values from json fastly.
 /// LazyValue is only generated when using `get` or `Iterator` or `from_string`.
@@ -28,8 +29,8 @@ pub struct LazyValue<'de> {
     own: UnsafeCell<Vec<u8>>,
 }
 
-impl<'de> JsonValue for LazyValue<'de> {
-    type ValueType<'dom> = LazyValue<'dom> where Self: 'dom;
+impl<'de> JsonValueTrait for LazyValue<'de> {
+    type ValueType<'v> = LazyValue<'v> where Self: 'v;
 
     fn as_bool(&self) -> Option<bool> {
         match self.raw.as_ref() {
@@ -69,7 +70,7 @@ impl<'de> JsonValue for LazyValue<'de> {
         }
     }
 
-    fn get<I: crate::value::Index>(&self, index: I) -> Option<Self::ValueType<'_>> {
+    fn get<I: Index>(&self, index: I) -> Option<Self::ValueType<'_>> {
         index.lazyvalue_index_into(self)
     }
 
@@ -187,9 +188,9 @@ impl<'de> LazyValue<'de> {
 
 #[cfg(test)]
 mod test {
-    use crate::value::JsonValue;
+    use crate::to_array_iter;
+    use crate::value::JsonValueTrait;
     use crate::{get_unchecked, pointer};
-    use crate::{to_array_iter, PointerNode};
 
     use super::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod reader;
 mod util;
 
 pub mod format;
+pub mod index;
 pub mod lazyvalue;
 pub mod serde;
 pub mod value;
@@ -25,12 +26,12 @@ pub use crate::lazyvalue::{
     get, get_from_bytes, get_from_bytes_unchecked, get_from_faststr, get_from_faststr_unchecked,
     get_from_slice, get_from_slice_unchecked, get_from_str, get_from_str_unchecked, get_many,
     get_many_unchecked, get_unchecked, to_array_iter, to_array_iter_unchecked, to_object_iter,
-    to_object_iter_unchecked, ArrayIntoIter, LazyValue, ObjectIntoIter, UnsafeArrayIntoIter,
-    UnsafeObjectIntoIter,
+    to_object_iter_unchecked, ArrayJsonIter, LazyValue, ObjectJsonIter, UnsafeArrayJsonIter,
+    UnsafeObjectJsonIter,
 };
 
 #[doc(inline)]
-pub use crate::pointer::{JsonPointer, PointerNode, PointerTrait, PointerTree};
+pub use crate::pointer::{JsonPointer, PointerNode, PointerTree};
 
 #[doc(inline)]
 pub use crate::serde::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
+#![feature(slice_range)]
+#![feature(no_sanitize)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 #![allow(dead_code)]
+
 mod error;
 mod input;
 mod parser;
 mod pointer;
-mod reader;
+pub mod reader;
 mod util;
 
 pub mod format;
@@ -38,8 +41,8 @@ pub use crate::serde::{
 
 #[doc(inline)]
 pub use crate::value::{
-    dom_from_slice, dom_from_slice_unchecked, dom_from_str, Array, ArrayMut, Document, JsonType,
-    JsonValue, Object, ObjectMut, Value, ValueMut,
+    from_value, to_value, Array, JsonContainerTrait, JsonType, JsonValueMutTrait, JsonValueTrait,
+    Object, Value, ValueRef,
 };
 
 // re-export the serde trait

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,11 @@
 use super::reader::{Reader, Reference};
 use crate::error::ErrorCode::{self, *};
 use crate::error::{Error, Result};
-use crate::pointer::{
-    tree::MultiIndex, tree::MultiKey, tree::PointerTreeInner, tree::PointerTreeNode, PointerTrait,
-};
+use crate::index::Index;
+use crate::pointer::tree::MultiIndex;
+use crate::pointer::tree::MultiKey;
+use crate::pointer::tree::PointerTreeInner;
+use crate::pointer::tree::PointerTreeNode;
 use crate::pointer::{JsonPointer, PointerTree};
 use crate::util::arc::Arc;
 use crate::util::arch::{get_nonspace_bits, prefix_xor};
@@ -1926,14 +1928,14 @@ where
 
     pub(crate) fn get_from_with_iter<P: IntoIterator>(&mut self, path: P) -> Result<&'de [u8]>
     where
-        P::Item: PointerTrait,
+        P::Item: Index,
     {
         // temp buf reused when parsing each escaped key
         let mut temp_buf = Vec::with_capacity(DEFAULT_KEY_BUF_CAPACITY);
         for jp in path.into_iter() {
-            if let Some(key) = jp.key() {
+            if let Some(key) = jp.as_key() {
                 self.get_from_object(key, &mut temp_buf)
-            } else if let Some(index) = jp.index() {
+            } else if let Some(index) = jp.as_index() {
                 self.get_from_array(index)
             } else {
                 unreachable!();
@@ -1948,14 +1950,14 @@ where
         path: P,
     ) -> Result<&'de [u8]>
     where
-        P::Item: PointerTrait,
+        P::Item: Index,
     {
         // temp buf reused when parsing each escaped key
         let mut temp_buf = Vec::with_capacity(DEFAULT_KEY_BUF_CAPACITY);
         for jp in path.into_iter() {
-            if let Some(key) = jp.key() {
+            if let Some(key) = jp.as_key() {
                 self.get_from_object_checked(key, &mut temp_buf)
-            } else if let Some(index) = jp.index() {
+            } else if let Some(index) = jp.as_index() {
                 self.get_from_array_checked(index)
             } else {
                 unreachable!();

--- a/src/pointer/from.rs
+++ b/src/pointer/from.rs
@@ -1,0 +1,32 @@
+use crate::PointerNode;
+use faststr::FastStr;
+
+impl From<usize> for PointerNode {
+    fn from(value: usize) -> Self {
+        PointerNode::Index(value)
+    }
+}
+
+impl From<&usize> for PointerNode {
+    fn from(value: &usize) -> Self {
+        PointerNode::Index(*value)
+    }
+}
+
+impl From<&str> for PointerNode {
+    fn from(value: &str) -> Self {
+        PointerNode::Key(FastStr::new(value))
+    }
+}
+
+impl From<FastStr> for PointerNode {
+    fn from(value: FastStr) -> Self {
+        PointerNode::Key(value)
+    }
+}
+
+impl From<&FastStr> for PointerNode {
+    fn from(value: &FastStr) -> Self {
+        PointerNode::Key(value.clone())
+    }
+}

--- a/src/pointer/mod.rs
+++ b/src/pointer/mod.rs
@@ -1,5 +1,6 @@
+mod from;
 pub(crate) mod point;
 pub(crate) mod tree;
 
-pub use point::{JsonPointer, PointerNode, PointerTrait};
+pub use point::{JsonPointer, PointerNode};
 pub use tree::PointerTree;

--- a/src/pointer/point.rs
+++ b/src/pointer/point.rs
@@ -49,11 +49,11 @@ pub type JsonPointer<'a> = Vec<PointerNode>;
 #[macro_export]
 macro_rules! pointer {
     () => (
-        std::vec::Vec::<PointerNode>::new()
+        std::vec::Vec::<$crate::PointerNode>::new()
     );
     ($($x:expr),+ $(,)?) => (
         <[_]>::into_vec(
-            std::boxed::Box::new([$(PointerNode::from($x)),+])
+            std::boxed::Box::new([$($crate::PointerNode::from($x)),+])
         )
     );
 }
@@ -90,8 +90,6 @@ impl<'a> PointerTrait for &'a usize {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-
     #[test]
     fn test_json_pointer() {
         let pointers = pointer![];

--- a/src/pointer/point.rs
+++ b/src/pointer/point.rs
@@ -1,23 +1,5 @@
 use faststr::FastStr;
 
-/// PointerTrait is a trait for the node in json pointer path.
-pub trait PointerTrait {
-    fn key(&self) -> Option<&str>;
-    fn index(&self) -> Option<usize>;
-}
-
-impl From<usize> for PointerNode {
-    fn from(value: usize) -> Self {
-        PointerNode::Index(value)
-    }
-}
-
-impl From<&'static str> for PointerNode {
-    fn from(value: &'static str) -> Self {
-        PointerNode::Key(FastStr::from_static_str(value))
-    }
-}
-
 /// JsonPointer reprsents a json path.
 /// You can use `jsonpointer!["a", "b", 1]` represent a json path.
 /// It means that we will get the json field from `.a.b.1`.
@@ -26,22 +8,6 @@ impl From<&'static str> for PointerNode {
 pub enum PointerNode {
     Key(FastStr),
     Index(usize),
-}
-
-impl PointerTrait for &PointerNode {
-    fn index(&self) -> Option<usize> {
-        match self {
-            PointerNode::Index(idx) => Some(*idx),
-            PointerNode::Key(_) => None,
-        }
-    }
-
-    fn key(&self) -> Option<&str> {
-        match self {
-            PointerNode::Key(key) => Some(key),
-            PointerNode::Index(_) => None,
-        }
-    }
 }
 
 pub type JsonPointer<'a> = Vec<PointerNode>;
@@ -56,36 +22,6 @@ macro_rules! pointer {
             std::boxed::Box::new([$($crate::PointerNode::from($x)),+])
         )
     );
-}
-
-impl<'a> PointerTrait for &'a FastStr {
-    fn index(&self) -> Option<usize> {
-        None
-    }
-
-    fn key(&self) -> Option<&str> {
-        Some(self.as_str())
-    }
-}
-
-impl<'a> PointerTrait for &'a &str {
-    fn index(&self) -> Option<usize> {
-        None
-    }
-
-    fn key(&self) -> Option<&str> {
-        Some(self)
-    }
-}
-
-impl<'a> PointerTrait for &'a usize {
-    fn index(&self) -> Option<usize> {
-        Some(**self)
-    }
-
-    fn key(&self) -> Option<&str> {
-        None
-    }
 }
 
 #[cfg(test)]

--- a/src/pointer/tree.rs
+++ b/src/pointer/tree.rs
@@ -1,6 +1,5 @@
 use super::PointerTrait;
 use faststr::FastStr;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 /// PointerTree is designed for `get_many`.
@@ -50,7 +49,6 @@ pub(crate) struct PointerTreeNode {
     pub(crate) order: Vec<usize>,
     pub(crate) children: PointerTreeInner,
 }
-
 use PointerTreeInner::{Empty, Index, Key};
 
 impl PointerTreeNode {
@@ -78,10 +76,7 @@ impl PointerTreeNode {
 
     fn insert_key(&mut self, key: &str) -> &mut Self {
         if let Key(mkey) = &mut self.children {
-            match mkey.entry(FastStr::new(key)) {
-                Entry::Occupied(o) => o.into_mut(),
-                Entry::Vacant(v) => v.insert(Self::default()),
-            }
+            mkey.entry(FastStr::new(key)).or_insert(Self::default())
         } else {
             unreachable!()
         }
@@ -89,10 +84,7 @@ impl PointerTreeNode {
 
     fn insert_index(&mut self, idx: usize) -> &mut Self {
         if let Index(midx) = &mut self.children {
-            match midx.entry(idx) {
-                Entry::Occupied(o) => o.into_mut(),
-                Entry::Vacant(v) => v.insert(Self::default()),
-            }
+            midx.entry(idx).or_insert(Self::default())
         } else {
             unreachable!()
         }
@@ -108,7 +100,6 @@ pub(crate) type MultiIndex = HashMap<usize, PointerTreeNode>;
 mod test {
     use super::*;
     use crate::pointer;
-    use crate::PointerNode;
 
     #[test]
     fn test_tree() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -60,6 +60,8 @@ pub trait Reader<'de>: Sealed {
     fn at(&self, index: usize) -> u8;
     fn set_index(&mut self, index: usize);
     fn next_n(&mut self, n: usize) -> Option<&'de [u8]>;
+
+    #[inline(always)]
     fn next(&mut self) -> Option<u8> {
         self.peek().map(|a| {
             self.eat(1);

--- a/src/serde/raw.rs
+++ b/src/serde/raw.rs
@@ -36,6 +36,12 @@ impl RawValue {
     }
 }
 
+impl AsRef<str> for RawValue {
+    fn as_ref(&self) -> &str {
+        &self.json
+    }
+}
+
 impl Clone for Box<RawValue> {
     fn clone(&self) -> Self {
         (**self).to_owned()

--- a/src/util/arc.rs
+++ b/src/util/arc.rs
@@ -1,0 +1,154 @@
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ptr::NonNull;
+use std::sync::atomic;
+use std::sync::atomic::Ordering::Acquire;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::Ordering::Release;
+
+use crate::field_offset;
+
+pub struct Arc<T> {
+    ptr: NonNull<ArcInner<T>>,
+    phantom: PhantomData<ArcInner<T>>,
+}
+
+impl<T> Arc<T> {
+    pub fn new(data: T) -> Arc<T> {
+        let x = Box::into_raw(Box::new(ArcInner {
+            refcnt: atomic::AtomicUsize::new(1),
+            data,
+        }));
+        Self {
+            ptr: unsafe { NonNull::new_unchecked(x) },
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn from_raw(ptr: *const T) -> Arc<T> {
+        let offset = field_offset!(ArcInner<T>, data);
+        let ptr = (ptr as *mut u8).sub(offset) as *mut ArcInner<T>;
+        Self {
+            ptr: NonNull::new_unchecked(ptr),
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn clone_from_raw(ptr: *const T) -> Arc<T> {
+        let now = Self::from_raw(ptr);
+        let ret = now.clone();
+        std::mem::forget(now);
+        ret
+    }
+
+    #[inline]
+    pub(crate) fn inner(&self) -> &ArcInner<T> {
+        unsafe { self.ptr.as_ref() }
+    }
+
+    #[inline]
+    pub(crate) fn refcnt(&self) -> usize {
+        self.inner().refcnt.load(Relaxed)
+    }
+
+    #[inline]
+    pub(crate) fn inner_ptr(&self) -> *const ArcInner<T> {
+        self.ptr.as_ptr()
+    }
+
+    #[inline]
+    pub(crate) fn data_ptr(&self) -> *const T {
+        &self.inner().data as *const T
+    }
+}
+
+impl<T> Deref for Arc<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.inner().data
+    }
+}
+
+impl<T: Display> Display for Arc<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+
+impl<T> Drop for Arc<T> {
+    #[inline]
+    fn drop(&mut self) {
+        // Because `fetch_sub` is already atomic, we do not need to synchronize
+        // with other threads unless we are going to delete the object.
+        if self.inner().refcnt.fetch_sub(1, Release) != 1 {
+            return;
+        }
+
+        // TODO: fix me when using ThreadSanitizer
+        // ThreadSanitizer does not support memory fences. To avoid false positive
+        // reports in Arc / Weak implementation use atomic loads for synchronization
+        // instead.
+        atomic::fence(Acquire);
+
+        let inner = unsafe { Box::from_raw(self.ptr.as_ptr()) };
+        drop(inner);
+    }
+}
+
+impl<T> Clone for Arc<T> {
+    #[inline]
+    fn clone(&self) -> Arc<T> {
+        // Using a relaxed ordering is alright here, as knowledge of the
+        // original reference prevents other threads from erroneously deleting
+        // the object.
+        //
+        self.inner().refcnt.fetch_add(1, Relaxed);
+
+        Self {
+            ptr: self.ptr,
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub(crate) struct ArcInner<T> {
+    data: T,
+    refcnt: atomic::AtomicUsize,
+}
+
+impl<T> ArcInner<T> {
+    #[inline]
+    pub(crate) fn new(data: T) -> Self {
+        Self {
+            refcnt: atomic::AtomicUsize::new(1),
+            data,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn data(&self) -> &T {
+        &self.data
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_arc() {
+        let x = Arc::new(42);
+        let y = x.clone();
+        assert_eq!(*x, 42);
+        assert_eq!(*y, 42);
+    }
+}

--- a/src/util/arch/x86_64.rs
+++ b/src/util/arch/x86_64.rs
@@ -9,6 +9,7 @@ pub unsafe fn prefix_xor(bitmask: u64) -> u64 {
     }
 }
 
+#[inline(always)]
 pub unsafe fn get_nonspace_bits(data: &[u8; 64]) -> u64 {
     unsafe {
         let lo: std::arch::x86_64::__m256i = _mm256_loadu_si256(data.as_ptr() as *const __m256i);

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,10 @@
-pub mod arch;
-pub mod num;
-pub mod private;
-pub mod string;
-pub mod unicode;
-pub mod utf8;
+pub(crate) mod arc;
+pub(crate) mod arch;
+pub(crate) mod num;
+pub(crate) mod offset;
+pub(crate) mod private;
+pub(crate) mod reborrow;
+pub(crate) mod string;
+pub(crate) mod taggedptr;
+pub(crate) mod unicode;
+pub(crate) mod utf8;

--- a/src/util/num/mod.rs
+++ b/src/util/num/mod.rs
@@ -377,7 +377,7 @@ fn parse_float(
 
     // check inf for float
     if float.is_infinite() {
-        return Err(ErrorCode::NumberOutOfRange);
+        return Err(ErrorCode::FloatMustBeFinite);
     }
     Ok(ParserNumber::Float(float))
 }

--- a/src/util/offset.rs
+++ b/src/util/offset.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! field_offset {
+    ($type:ty, $field:tt) => {{
+        let dummy = std::mem::MaybeUninit::<$type>::uninit();
+        let dummy_ptr = dummy.as_ptr();
+        let member_ptr = unsafe { std::ptr::addr_of!((*dummy_ptr).$field) };
+        member_ptr as usize - dummy_ptr as usize
+    }};
+}

--- a/src/util/private.rs
+++ b/src/util/private.rs
@@ -1,4 +1,4 @@
-use crate::reader::{SliceRead, UncheckedSliceRead};
+use crate::reader::{PaddedSliceRead, SliceRead};
 use bytes::Bytes;
 use faststr::FastStr;
 
@@ -11,6 +11,6 @@ impl Sealed for FastStr {}
 impl Sealed for Bytes {}
 impl Sealed for u8 {}
 impl<'de> Sealed for SliceRead<'de> {}
-impl<'de> Sealed for UncheckedSliceRead<'de> {}
+impl<'de> Sealed for PaddedSliceRead<'de> {}
 impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
 impl<T> Sealed for [T] where T: Sized + Sealed {}

--- a/src/util/private.rs
+++ b/src/util/private.rs
@@ -1,4 +1,5 @@
 use crate::reader::{PaddedSliceRead, SliceRead};
+use crate::PointerNode;
 use bytes::Bytes;
 use faststr::FastStr;
 
@@ -14,3 +15,4 @@ impl<'de> Sealed for SliceRead<'de> {}
 impl<'de> Sealed for PaddedSliceRead<'de> {}
 impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
 impl<T> Sealed for [T] where T: Sized + Sealed {}
+impl Sealed for PointerNode {}

--- a/src/util/reborrow.rs
+++ b/src/util/reborrow.rs
@@ -1,0 +1,74 @@
+// Copied from Rust-lang BTreeMap implementation
+
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+
+/// Models a reborrow of some unique reference, when you know that the reborrow
+/// and all its descendants (i.e., all pointers and references derived from it)
+/// will not be used any more at some point, after which you want to use the
+/// original unique reference again.
+///
+/// The borrow checker usually handles this stacking of borrows for you, but
+/// some control flows that accomplish this stacking are too complicated for
+/// the compiler to follow. A `DormantMutRef` allows you to check borrowing
+/// yourself, while still expressing its stacked nature, and encapsulating
+/// the raw pointer code needed to do this without undefined behavior.
+pub struct DormantMutRef<'a, T> {
+    ptr: NonNull<T>,
+    _marker: PhantomData<&'a mut T>,
+}
+
+unsafe impl<'a, T> Sync for DormantMutRef<'a, T> where &'a mut T: Sync {}
+unsafe impl<'a, T> Send for DormantMutRef<'a, T> where &'a mut T: Send {}
+
+impl<'a, T> DormantMutRef<'a, T> {
+    /// Capture a unique borrow, and immediately reborrow it. For the compiler,
+    /// the lifetime of the new reference is the same as the lifetime of the
+    /// original reference, but you promise to use it for a shorter period.
+    pub fn new(t: &'a mut T) -> (&'a mut T, Self) {
+        let ptr = NonNull::from(t);
+        // SAFETY: we hold the borrow throughout 'a via `_marker`, and we expose
+        // only this reference, so it is unique.
+        let new_ref = unsafe { &mut *ptr.as_ptr() };
+        (
+            new_ref,
+            Self {
+                ptr,
+                _marker: PhantomData,
+            },
+        )
+    }
+
+    /// Revert to the unique borrow initially captured.
+    ///
+    /// # Safety
+    ///
+    /// The reborrow must have ended, i.e., the reference returned by `new` and
+    /// all pointers and references derived from it, must not be used anymore.
+    pub unsafe fn awaken(self) -> &'a mut T {
+        // SAFETY: our own safety conditions imply this reference is again unique.
+        unsafe { &mut *self.ptr.as_ptr() }
+    }
+
+    /// Borrows a new mutable reference from the unique borrow initially captured.
+    ///
+    /// # Safety
+    ///
+    /// The reborrow must have ended, i.e., the reference returned by `new` and
+    /// all pointers and references derived from it, must not be used anymore.
+    pub unsafe fn reborrow(&mut self) -> &'a mut T {
+        // SAFETY: our own safety conditions imply this reference is again unique.
+        unsafe { &mut *self.ptr.as_ptr() }
+    }
+
+    /// Borrows a new shared reference from the unique borrow initially captured.
+    ///
+    /// # Safety
+    ///
+    /// The reborrow must have ended, i.e., the reference returned by `new` and
+    /// all pointers and references derived from it, must not be used anymore.
+    pub unsafe fn reborrow_shared(&self) -> &'a T {
+        // SAFETY: our own safety conditions imply this reference is again unique.
+        unsafe { &*self.ptr.as_ptr() }
+    }
+}

--- a/src/util/taggedptr.rs
+++ b/src/util/taggedptr.rs
@@ -1,0 +1,80 @@
+use std::mem::transmute;
+
+/// TaggpedPtr is a pointer of T with a tag.
+///
+#[derive(Debug)]
+pub(crate) struct TaggedPtr<T> {
+    // ptr is allow null ptr
+    ptr: *const u8,
+    _marker: std::marker::PhantomData<*const T>,
+}
+
+impl<T> TaggedPtr<T> {
+    const TAG_MASK: usize = std::mem::align_of::<T>() - 1;
+    const PTR_MASK: usize = !Self::TAG_MASK;
+
+    #[inline]
+    pub const fn new(ptr: *const T, tag: usize) -> Self {
+        let mut slf = Self {
+            ptr: ptr.cast(),
+            _marker: std::marker::PhantomData,
+        };
+        #[allow(clippy::transmutes_expressible_as_ptr_casts)]
+        let mut raw: usize = unsafe { transmute(slf.ptr) };
+        raw |= tag;
+        slf.ptr = raw as *const u8;
+        slf
+    }
+
+    #[inline]
+    pub fn set_tag(&mut self, tag: usize) {
+        let mut raw = self.ptr as usize;
+        raw &= Self::PTR_MASK;
+        raw |= tag;
+        self.ptr = raw as *const u8;
+    }
+
+    #[inline]
+    pub fn tag(&self) -> usize {
+        (self.ptr as usize) & Self::TAG_MASK
+    }
+
+    #[inline]
+    pub fn ptr(&self) -> *const T {
+        ((self.ptr as usize) & Self::PTR_MASK) as *const T
+    }
+
+    #[inline]
+    pub fn set_ptr(&mut self, ptr: *const T) {
+        let tag = self.tag();
+        self.ptr = ((ptr as usize) | tag) as *const u8;
+    }
+
+    #[inline]
+    pub fn addr(&self) -> usize {
+        self.ptr as usize
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[repr(align(16))]
+    struct Fox;
+
+    #[test]
+    fn test_taggedptr() {
+        let f = Fox;
+        let f2 = Fox;
+        let mut tagged: TaggedPtr<Fox> = TaggedPtr::new(&f as *const _, 0xf);
+        assert_eq!(tagged.tag(), 0xf);
+        tagged.set_tag(2);
+        assert_eq!(tagged.tag(), 2);
+        assert_eq!(tagged.ptr(), &f as *const _);
+
+        tagged.set_ptr(&f2 as *const _);
+        assert_eq!(tagged.tag(), 2);
+        assert_eq!(tagged.ptr(), &f2 as *const _);
+    }
+}

--- a/src/value/alloctor.rs
+++ b/src/value/alloctor.rs
@@ -1,0 +1,69 @@
+use bumpalo::Bump;
+use parking_lot::Mutex;
+use std::{alloc::Layout, ptr::NonNull};
+
+#[derive(Debug)]
+pub(crate) struct SyncBump(pub(crate) Mutex<Bump>);
+
+#[derive(Debug)]
+pub(crate) struct AllocError;
+
+impl std::error::Error for AllocError {}
+
+impl std::fmt::Display for AllocError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("alloc error")
+    }
+}
+
+pub(crate) trait AllocatorTrait {
+    fn try_alloc_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocError>;
+
+    fn deallocate(&self, ptr: NonNull<u8>, layout: Layout);
+
+    fn allocate(&self, layout: Layout) -> NonNull<u8> {
+        self.try_alloc_layout(layout).expect("OOM, too big layout")
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    fn alloc_str(&self, s: &str) -> &mut str {
+        let layout = Layout::from_size_align(s.len(), 1).unwrap();
+        let ptr = self.allocate(layout);
+        unsafe {
+            std::ptr::copy_nonoverlapping(s.as_ptr(), ptr.as_ptr(), s.len());
+        }
+        unsafe {
+            std::str::from_utf8_unchecked_mut(std::slice::from_raw_parts_mut(ptr.as_ptr(), s.len()))
+        }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    fn alloc_slice<T>(&self, len: usize) -> &mut [T] {
+        let layout = Layout::array::<T>(len).expect("OOM, too big layout");
+        let ptr = self.allocate(layout);
+        unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, len) }
+    }
+}
+
+impl Default for SyncBump {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncBump {
+    pub fn new() -> Self {
+        Self(Mutex::new(Bump::new()))
+    }
+}
+
+impl AllocatorTrait for SyncBump {
+    fn try_alloc_layout(&self, layout: Layout) -> Result<NonNull<u8>, AllocError> {
+        self.0
+            .lock()
+            .try_alloc_layout(layout)
+            .map_err(|_| AllocError)
+    }
+
+    fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {}
+}

--- a/src/value/alloctor.rs
+++ b/src/value/alloctor.rs
@@ -52,7 +52,7 @@ impl Default for SyncBump {
 }
 
 impl SyncBump {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(Mutex::new(Bump::new()))
     }
 }

--- a/src/value/array.rs
+++ b/src/value/array.rs
@@ -1,0 +1,925 @@
+use super::shared::Shared;
+use crate::serde::tri;
+use crate::util::arc::Arc;
+use crate::value::from::SharedCtxGuard;
+use crate::value::node::Value;
+use crate::value::value_trait::JsonValueTrait;
+use std::fmt::Debug;
+use std::iter::FusedIterator;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::ops::Range;
+use std::ops::RangeBounds;
+use std::ptr::NonNull;
+use std::slice::from_raw_parts;
+use std::slice::from_raw_parts_mut;
+
+/// Array represents a JSON array. Its most APIs are as `Array<Value>`.
+///
+#[derive(Debug, Eq, PartialEq, Clone)]
+#[repr(transparent)]
+pub struct Array(pub(crate) Value);
+
+pub(crate) const DEFAULT_ARRAY_CAP: usize = 8;
+
+impl Array {
+    /// Returns the inner [`Value`].
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+
+    /// Constructs a new, empty `Array`.
+    ///
+    /// The array will not allocate until elements are pushed onto it.
+    ///
+    #[inline]
+    pub const fn new() -> Self {
+        let value = Value {
+            meta: super::node::Meta::new(super::node::ROOT_ARRAY, std::ptr::null()),
+            data: super::node::Data {
+                achildren: std::ptr::null_mut(),
+            },
+        };
+        Array(value)
+    }
+
+    /// Constructs a new, empty `Array` with at least the specified capacity.
+    ///
+    /// The array will be able to hold at least `capacity` elements without
+    /// reallocating. This method is allowed to allocate for more elements than
+    /// `capacity`. If `capacity` is 0, the array will not allocate.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut array = Self::new();
+        array.reserve(capacity);
+        array
+    }
+
+    /// Reserves capacity for at least `additional` more elements to be inserted
+    /// in the given `Array`. The collection may reserve more space to
+    /// speculatively avoid frequent reallocations. After calling `reserve`,
+    /// capacity will be greater than or equal to `self.len() + additional`.
+    /// Does nothing if capacity is already sufficient.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3];
+    /// arr.reserve(10);
+    /// assert!(arr.capacity() >= 13);
+    /// ```
+    ///
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve::<Value>(additional);
+    }
+
+    /// Resizes the `Array` in-place so that `len` is equal to `new_len`.
+    ///
+    /// If `new_len` is greater than `len`, the `Array` is extended by the
+    /// difference, with each additional slot filled with the `Value` converted from `value`.
+    /// If `new_len` is less than `len`, the `Array` is simply truncated.
+    ///
+    /// If you need more flexibility, use [`Array::resize_with`].
+    /// If you only need to resize to a smaller size, use [`Array::truncate`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{array, json};
+    ///
+    /// let mut arr = array!["hello"];
+    /// arr.resize(3, "world");
+    /// assert_eq!(arr, ["hello", "world", "world"]);
+    ///
+    /// arr.resize(2, 0);
+    /// assert_eq!(arr, ["hello", "world"]);
+    ///
+    /// arr.resize(4, json!("repeat"));
+    /// assert_eq!(arr, array!["hello", "world", "repeat", "repeat"]);
+    /// ```
+    #[inline]
+    pub fn resize<T: Clone + Into<Value>>(&mut self, new_len: usize, value: T) {
+        if new_len > self.len() {
+            self.reserve(new_len - self.len());
+            for _ in self.len()..new_len {
+                self.push(value.clone().into());
+            }
+        } else {
+            self.truncate(new_len);
+        }
+    }
+
+    /// Resizes the `Array` in-place so that `len` is equal to `new_len`.
+    ///
+    /// If `new_len` is greater than `len`, the `Array` is extended by the
+    /// difference, with each additional slot filled with the result of
+    /// calling the closure `f`. The return values from `f` will end up
+    /// in the `Array` in the order they have been generated.
+    ///
+    /// If `new_len` is less than `len`, the `Array` is simply truncated.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3];
+    /// arr.resize_with(5, Default::default);
+    /// assert_eq!(arr, array![1, 2, 3, null, null]);
+    ///
+    /// let mut arr = array![];
+    /// let mut p = 1;
+    /// arr.resize_with(4, || { p *= 2; p.into() });
+    /// assert_eq!(arr, [2, 4, 8, 16]);
+    /// ```
+    #[inline]
+    pub fn resize_with<F>(&mut self, new_len: usize, mut f: F)
+    where
+        F: FnMut() -> Value,
+    {
+        if new_len > self.len() {
+            self.reserve(new_len - self.len());
+            for _ in self.len()..new_len {
+                self.push(f());
+            }
+        } else {
+            self.truncate(new_len);
+        }
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all elements `e` for which `f(&e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    ///
+    /// Because the elements are visited exactly once in the original order,
+    /// external state may be used to decide which elements to keep.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3, 4, 5];
+    /// let keep = [false, true, true, false, true];
+    /// let mut iter = keep.iter();
+    /// arr.retain(|_| *iter.next().unwrap());
+    /// assert_eq!(arr, array![2, 3, 5]);
+    /// ```
+    #[inline]
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Value) -> bool,
+    {
+        self.retain_mut(|elem| f(elem));
+    }
+
+    /// Splits the collection into two at the given index.
+    ///
+    /// Returns a newly allocated array containing the elements in the range
+    /// `[at, len)`. After the call, the original array will be left containing
+    /// the elements `[0, at)` with its previous capacity unchanged.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3];
+    /// let arr2 = arr.split_off(1);
+    /// assert_eq!(arr, [1]);
+    /// assert_eq!(arr2, [2, 3]);
+    /// assert_eq!(arr.split_off(1), array![]);
+    /// ```
+    #[inline]
+    pub fn split_off(&mut self, at: usize) -> Self {
+        let len = self.len();
+        assert!(at <= len, "at {} out of bounds(len: {})", at, len);
+
+        let mut arr = Self::new_in(self.0.shared_clone());
+        if at == len {
+            return arr;
+        }
+        arr.reserve(len - at);
+
+        unsafe {
+            let src = self.as_mut_ptr().add(at);
+            let dst = arr.as_mut_ptr();
+            std::ptr::copy_nonoverlapping(src, dst, len - at);
+            self.set_len(at);
+            arr.set_len(len - at);
+        }
+        arr
+    }
+
+    /// Removes an element from the array and returns it.
+    ///
+    /// The removed element is replaced by the last element of the array.
+    ///
+    /// This does not preserve ordering, but is *O*(1).
+    /// If you need to preserve the element order, use [`remove`] instead.
+    ///
+    /// [`remove`]: Array::remove
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut v = array!["foo", "bar", "baz", "qux"];
+    ///
+    /// assert_eq!(v.swap_remove(1), "bar");
+    /// assert_eq!(v, ["foo", "qux", "baz"]);
+    ///
+    /// assert_eq!(v.swap_remove(0), "foo");
+    /// assert_eq!(v, ["baz", "qux"]);
+    /// ```
+    #[inline]
+    pub fn swap_remove(&mut self, index: usize) -> Value {
+        let len = self.len();
+        assert!(index < len, "index {} out of bounds(len: {})", index, len);
+        if index != self.len() - 1 {
+            unsafe {
+                let src = self.as_mut_ptr().add(index);
+                let dst = self.as_mut_ptr().add(len - 1);
+                std::ptr::swap(src, dst);
+            }
+        }
+        self.pop().unwrap()
+    }
+
+    /// Retains only the elements specified by the predicate, passing a mutable reference to it.
+    ///
+    /// In other words, remove all elements `e` such that `f(&mut e)` returns `false`.
+    /// This method operates in place, visiting each element exactly once in the
+    /// original order, and preserves the order of the retained elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// use sonic_rs::JsonValueTrait;
+    ///
+    /// let mut arr = array![1, 2, 3, 4];
+    /// arr.retain_mut(|x|  {
+    /// let v = (x.as_i64().unwrap());
+    /// if v <= 3 {
+    ///     *x = (v + 1).into();
+    ///     true
+    /// } else {
+    ///     false
+    /// }});
+    /// assert_eq!(arr, [2, 3, 4]);
+    /// ```
+    #[inline]
+    pub fn retain_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Value) -> bool,
+    {
+        if self.is_empty() {
+            return;
+        }
+
+        let mut i = 0;
+        let mut j = 0;
+        let start = self.as_mut_ptr();
+        while i < self.len() {
+            unsafe {
+                let cur = start.add(i);
+                if !f(&mut *cur) {
+                    (*cur).take();
+                    i += 1;
+                    continue;
+                }
+
+                if i > j {
+                    std::ptr::copy_nonoverlapping(cur, start.add(j), 1);
+                }
+                i += 1;
+                j += 1;
+            }
+        }
+
+        unsafe { self.set_len(j) };
+    }
+
+    /// Shortens the array, keeping the first `len` elements and dropping
+    /// the rest.
+    ///
+    /// If `len` is greater or equal to the array's current length, this has
+    /// no effect.
+    ///
+    /// The [`drain`] method can emulate `truncate`, but causes the excess
+    /// elements to be returned instead of dropped.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the array.
+    ///
+    /// # Examples
+    ///
+    /// Truncating a five element array to two elements:
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3, true, "hi"];
+    /// arr.truncate(2);
+    /// assert_eq!(arr, [1, 2]);
+    /// ```
+    ///
+    /// No truncation occurs when `len` is greater than the array's current
+    /// length:
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3];
+    /// arr.truncate(8);
+    /// assert_eq!(arr, [1, 2, 3]);
+    /// ```
+    ///
+    /// Truncating when `len == 0` is equivalent to calling the [`clear`]
+    /// method.
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2, 3];
+    /// arr.truncate(0);
+    /// assert!(arr.is_empty());
+    /// ```
+    ///
+    /// [`clear`]: Array::clear
+    /// [`drain`]: Array::drain
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        let old_len = self.len();
+        if len < old_len {
+            unsafe {
+                let mut v = self.as_mut_ptr().add(len);
+                let end = self.as_mut_ptr().add(old_len);
+
+                while v != end {
+                    (*v).take();
+                    v = v.add(1);
+                }
+            }
+            unsafe { self.set_len(len) };
+        }
+    }
+
+    /// Appends an element `val` to the back of a collection.
+    /// The `val` will be converted into `Value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    /// let mut arr = array![1, 2];
+    /// arr.push(3);
+    /// arr.push("hi");
+    /// assert_eq!(arr, array![1, 2, 3, "hi"]);
+    /// ```
+    #[inline]
+    pub fn push<T: Into<Value>>(&mut self, val: T) {
+        self.reserve(1);
+        let val = {
+            let _ = SharedCtxGuard::assign(self.0.shared());
+            val.into()
+        };
+        self.0.append_value(val);
+    }
+
+    /// Removes the last element from a array and returns it, or [`None`] if it is empty.
+    #[inline]
+    pub fn pop(&mut self) -> Option<Value> {
+        debug_assert!(self.0.is_array());
+        self.0.pop()
+    }
+
+    /// Returns the number of elements in the array.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the array contains no elements.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.len() == 0
+    }
+
+    /// Extracts a mutable slice of the entire array. Equivalent to &mut s[..].
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [Value] {
+        self
+    }
+
+    /// Extracts a slice containing the entire array. Equivalent to &s[..].
+    #[inline]
+    pub fn as_slice(&self) -> &[Value] {
+        self
+    }
+
+    /// Returns the total number of elements the array can hold without reallocating.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Clears the array, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity of the array.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Removes and returns the element at position `index` within the array,
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::array;
+    ///
+    /// let mut arr = array![0, 1, 2];
+    /// arr.remove(1);
+    /// assert_eq!(arr, [0, 2]);
+    /// ```
+    #[inline]
+    pub fn remove(&mut self, index: usize) {
+        self.0.remove_index(index);
+    }
+
+    /// Moves all the elements of other into self, leaving other empty.
+    ///
+    /// # Examples
+    /// ```
+    /// use sonic_rs::{array, Value};
+    ///
+    /// let mut arr1 = array![1];
+    /// arr1.push(Value::from("arr1"));
+    ///
+    /// let mut arr2 = array![2];
+    /// arr2.push(Value::from("arr2"));
+    /// arr2.append(&mut arr1);
+    ///
+    /// assert_eq!(arr2, array![2, "arr2", "arr1", 1]);
+    /// assert!(arr1.is_empty());
+    /// ```
+    #[inline]
+    pub fn append(&mut self, other: &mut Self) {
+        self.reserve(other.len());
+        while let Some(v) = other.pop() {
+            debug_assert!(v.is_root() || v.is_static());
+            self.push(v);
+        }
+    }
+
+    /// Removes the specified range from the array in bulk, returning all
+    /// removed elements as an iterator. If the iterator is dropped before
+    /// being fully consumed, it drops the remaining removed elements.
+    ///
+    /// The returned iterator keeps a mutable borrow on the array to optimize
+    /// its implementation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the starting point is greater than the end point or if
+    /// the end point is greater than the length of the array.
+    ///
+    /// # Leaking
+    ///
+    /// If the returned iterator goes out of scope without being dropped (due to
+    /// [`mem::forget`], for example), the array may have lost and leaked
+    /// elements arbitrarily, including elements outside the range.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{array, Value};
+    /// let mut v = array![1, 2, 3];
+    /// let u: Vec<Value> = v.drain(1..).collect();
+    /// assert_eq!(v, &[1]);
+    /// assert_eq!(u, &[2, 3]);
+    ///
+    /// // A full range clears the array, like `clear()` does
+    /// v.drain(..);
+    /// assert!(v.is_empty());
+    /// ```
+    #[inline]
+    pub fn drain<R>(&mut self, range: R) -> Drain<'_>
+    where
+        R: RangeBounds<usize>,
+    {
+        let len = self.len();
+        let Range { start, end } = std::slice::range(range, ..len);
+
+        unsafe {
+            // set self.arr length's to start, to be safe in case Drain is leaked
+            self.set_len(start);
+            let range_slice = std::slice::from_raw_parts(self.as_ptr().add(start), end - start);
+            Drain {
+                tail_start: end,
+                tail_len: len - end,
+                iter: range_slice.iter(),
+                arr: NonNull::from(self),
+            }
+        }
+    }
+
+    /// Copies elements from `src` range to the end of the array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the starting point is greater than the end point or if
+    /// the end point is greater than the length of the array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Array;
+    /// let mut arr: Array = sonic_rs::from_str("[0, 1, 2, 3, 4]").unwrap();
+    ///
+    /// arr.extend_from_within(2..);
+    /// assert_eq!(arr, [0, 1, 2, 3, 4, 2, 3, 4]);
+    ///
+    /// arr.extend_from_within(..2);
+    /// assert_eq!(arr, [0, 1, 2, 3, 4, 2, 3, 4, 0, 1]);
+    ///
+    /// arr.extend_from_within(4..8);
+    /// assert_eq!(arr, [0, 1, 2, 3, 4, 2, 3, 4, 0, 1, 4, 2, 3, 4]);
+    /// ```
+    pub fn extend_from_within<R>(&mut self, src: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        let range = std::slice::range(src, ..self.len());
+        if range.is_empty() {
+            return;
+        }
+
+        self.reserve(range.len());
+        unsafe {
+            let start = self.as_mut_ptr().add(range.start);
+            let end = self.as_mut_ptr().add(range.end);
+            let src = std::slice::from_raw_parts(start, end.offset_from(start) as usize);
+            for v in src.iter() {
+                self.0.append_value(v.clone_in(self.0.shared()));
+            }
+        }
+    }
+
+    /// Inserts an element at position `index` within the array, shifting all
+    /// elements after it to the right.
+    /// The `element` will be converted into `Value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index > len`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{array, json};
+    ///
+    /// let mut arr = array![1, 2, 3];
+    /// arr.insert(1, "inserted1");
+    /// assert_eq!(arr, array![1, "inserted1", 2, 3]);
+    ///
+    /// arr.insert(4, "inserted2");
+    /// assert_eq!(arr, array![1, "inserted1", 2, 3, "inserted2"]);
+    ///
+    /// arr.insert(5, json!({"a": 123})); // insert at the end
+    /// assert_eq!(arr, array![1, "inserted1", 2, 3, "inserted2", {"a": 123}]);
+    /// ```
+    #[inline]
+    pub fn insert<T: Into<Value>>(&mut self, index: usize, element: T) {
+        let element = {
+            let _ = SharedCtxGuard::assign(self.0.shared());
+            element.into()
+        };
+        self.0.insert_value(index, element);
+    }
+
+    #[inline]
+    pub(crate) fn new_in(shared: Arc<Shared>) -> Self {
+        let mut array = Array::default();
+        array.0.mark_shared(shared.data_ptr());
+        std::mem::forget(shared);
+        array
+    }
+
+    #[inline]
+    pub(crate) unsafe fn set_len(&mut self, new_len: usize) {
+        self.0.set_len(new_len);
+    }
+}
+
+impl Default for Array {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Deref for Array {
+    type Target = [Value];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe {
+            let start = self.0.data.achildren.add(Value::MEAT_NODE_COUNT);
+            let ptr = start as *const Value;
+            let len = self.0.len();
+            from_raw_parts(ptr, len)
+        }
+    }
+}
+
+impl DerefMut for Array {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe {
+            let ptr = self.0.data.achildren.add(Value::MEAT_NODE_COUNT);
+            let len = self.0.len();
+            from_raw_parts_mut(ptr, len)
+        }
+    }
+}
+
+/// A draining iterator for `Array<T>`.
+///
+/// This `struct` is created by [`Array::drain`].
+/// See its documentation for more.
+///
+pub struct Drain<'a> {
+    pub(super) tail_start: usize,
+    pub(super) tail_len: usize,
+    // the iter of remain slice
+    pub(super) iter: std::slice::Iter<'a, Value>,
+    // origin array
+    pub(super) arr: NonNull<Array>,
+}
+
+impl<'a> Drain<'a> {
+    #[inline]
+    pub fn as_slice(&self) -> &'a [Value] {
+        self.iter.as_slice()
+    }
+}
+
+impl Iterator for Drain<'_> {
+    type Item = Value;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .next()
+            .map(|v| v.clone_in(unsafe { self.arr.as_ref().0.shared() }))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+use std::ops::Index;
+use std::ops::IndexMut;
+use std::slice::SliceIndex;
+
+impl<I: SliceIndex<[Value]>> Index<I> for Array {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        Index::index(&**self, index)
+    }
+}
+
+impl<I: SliceIndex<[Value]>> IndexMut<I> for Array {
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
+        IndexMut::index_mut(&mut **self, index)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Default, Clone)]
+pub struct IntoIter {
+    array: Array,
+    index: usize,
+    len: usize,
+}
+
+impl IntoIter {
+    pub fn as_mut_slice(&mut self) -> &mut [Value] {
+        unsafe {
+            let ptr = self.array.0.children_mut_ptr();
+            let len = self.array.0.len();
+            from_raw_parts_mut(ptr, len)
+        }
+    }
+
+    pub fn as_slice(&self) -> &[Value] {
+        unsafe {
+            let ptr = self.array.0.children_ptr();
+            let len = self.array.0.len();
+            from_raw_parts(ptr, len)
+        }
+    }
+}
+
+impl AsRef<[Value]> for IntoIter {
+    fn as_ref(&self) -> &[Value] {
+        self.as_slice()
+    }
+}
+
+impl AsMut<[Value]> for IntoIter {
+    fn as_mut(&mut self) -> &mut [Value] {
+        self.as_mut_slice()
+    }
+}
+
+impl DoubleEndedIterator for IntoIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index < self.len {
+            self.len -= 1;
+            let value = self.array.0.get_index_mut(self.len).unwrap();
+            Some(value.take())
+        } else {
+            None
+        }
+    }
+}
+
+impl ExactSizeIterator for IntoIter {
+    #[inline]
+    fn len(&self) -> usize {
+        self.len - self.index
+    }
+}
+
+impl FusedIterator for IntoIter {}
+
+impl Iterator for IntoIter {
+    type Item = Value;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.len {
+            let value = self.array.0.get_index_mut(self.index).unwrap();
+            self.index += 1;
+            Some(value.take())
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len - self.index;
+        (len, Some(len))
+    }
+}
+
+impl IntoIterator for Array {
+    type Item = Value;
+    type IntoIter = IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self.len();
+        IntoIter {
+            array: self,
+            index: 0,
+            len,
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Array {
+    type Item = &'a Value;
+    type IntoIter = std::slice::Iter<'a, Value>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Array {
+    type Item = &'a mut Value;
+    type IntoIter = std::slice::IterMut<'a, Value>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+impl serde::ser::Serialize for Array {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = tri!(serializer.serialize_seq(Some(self.len())));
+        for v in self {
+            tri!(seq.serialize_element(v));
+        }
+        seq.end()
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Array {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        // deserialize to value at first
+        let value: Value =
+            deserializer.deserialize_newtype_struct(super::de::TOKEN, super::de::ValueVisitor)?;
+        if value.is_array() {
+            Ok(Array(value))
+        } else {
+            Err(serde::de::Error::invalid_type(
+                serde::de::Unexpected::Other("not a array"),
+                &"array",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Array;
+    use crate::value::node::Value;
+    use crate::value::value_trait::JsonValueMutTrait;
+
+    #[test]
+    fn test_value_array() {
+        let mut val = crate::from_str::<Value>(r#"[1,2,3]"#);
+        let array = val.as_array_mut().unwrap();
+        assert_eq!(array.len(), 3);
+
+        for i in 0..3 {
+            // push static node
+            let old_len = array.len();
+            let new_node = Value::new_u64(i, std::ptr::null());
+            array.push(new_node);
+            assert_eq!(array.len(), old_len + 1);
+
+            // push node with new allocator
+            let old_len = array.len();
+            let mut new_node = Array::default();
+            new_node.push(Value::new_u64(i, std::ptr::null()));
+            dbg!(&new_node.0);
+            array.push(new_node.0);
+            assert_eq!(array.len(), old_len + 1);
+
+            // push node with self allocator
+            let old_len = array.len();
+            let mut new_node = Array::new_in(array.0.shared_clone());
+            new_node.push(Value::new_u64(i, std::ptr::null()));
+            dbg!(&new_node.0);
+            array.push(new_node.0);
+            assert_eq!(array.len(), old_len + 1);
+        }
+
+        dbg!(&array);
+        for (i, v) in array.iter_mut().enumerate() {
+            *v = Value::new_u64(i as u64, std::ptr::null());
+        }
+
+        while !array.is_empty() {
+            dbg!(array.pop());
+        }
+    }
+}

--- a/src/value/array.rs
+++ b/src/value/array.rs
@@ -1,7 +1,7 @@
 use super::shared::Shared;
+use super::shared::SharedCtxGuard;
 use crate::serde::tri;
 use crate::util::arc::Arc;
-use crate::value::from::SharedCtxGuard;
 use crate::value::node::Value;
 use crate::value::value_trait::JsonValueTrait;
 use std::fmt::Debug;
@@ -18,6 +18,7 @@ use std::slice::from_raw_parts_mut;
 ///
 /// # Example
 /// ```
+/// use sonic_rs::JsonContainerTrait;
 /// use sonic_rs::{array, Array};
 ///
 /// let mut arr: Array = sonic_rs::from_str("[1, 2, 3]").unwrap();

--- a/src/value/array.rs
+++ b/src/value/array.rs
@@ -14,7 +14,21 @@ use std::ptr::NonNull;
 use std::slice::from_raw_parts;
 use std::slice::from_raw_parts_mut;
 
-/// Array represents a JSON array. Its most APIs are as `Array<Value>`.
+/// Array represents a JSON array. Its APIs are likes `Array<Value>`.
+///
+/// # Example
+/// ```
+/// use sonic_rs::{array, Array};
+///
+/// let mut arr: Array = sonic_rs::from_str("[1, 2, 3]").unwrap();
+/// assert_eq!(arr[0], 1);
+///
+/// let mut arr = array![1, 2, 3];
+/// assert_eq!(arr[0], 1);
+///
+/// let j = sonic_rs::json!([1, 2, 3]);
+/// assert_eq!(j.as_array().unwrap()[0], 1);
+/// ```
 ///
 #[derive(Debug, Eq, PartialEq, Clone)]
 #[repr(transparent)]
@@ -682,6 +696,7 @@ pub struct Drain<'a> {
 }
 
 impl<'a> Drain<'a> {
+    /// Returns the remaining items of its iterator as a slice.
     #[inline]
     pub fn as_slice(&self) -> &'a [Value] {
         self.iter.as_slice()

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,0 +1,734 @@
+use super::node::ValueRef;
+use crate::error::{Error, ErrorCode};
+use crate::reader::Reader;
+use crate::serde::number::N;
+use crate::serde::tri;
+use crate::value::node::Value;
+use crate::value::Object;
+use serde::de::Visitor;
+use serde::de::{
+    self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess,
+    SeqAccess, Unexpected, VariantAccess,
+};
+use serde::forward_to_deserialize_any;
+use std::mem::MaybeUninit;
+use std::result::Result as StdResult;
+use std::slice;
+
+/// Interpret a `sonic_rs::Value` as an instance of type `T`.
+///
+/// # Example
+///
+/// ```
+/// use serde::Deserialize;
+/// use sonic_rs::json;
+///
+/// #[derive(Deserialize, Debug)]
+/// struct User {
+///     string: String,
+///     number: i32,
+///     array: Vec<String>,
+/// }
+///
+///  // The type of `j` is `sonic_rs::Value`
+///  let j = json!({
+///      "string": "hello",
+///      "number": 123,
+///      "array": ["a", "b", "c"],
+///  });
+///  let u: User = sonic_rs::from_value(&j).unwrap();
+///  assert_eq!(u.string, "hello");
+///  assert_eq!(u.number, 123);
+///  assert_eq!(u.array, vec!["a", "b", "c"]);
+/// ```
+///
+/// # Errors
+///
+/// This conversion can fail if the structure of the Value does not match the
+/// structure expected by `T`, for example if `T` is a struct type but the Value
+/// contains something other than a JSON map. It can also fail if the structure
+/// is correct but `T`'s implementation of `Deserialize` decides that something
+/// is wrong with the data, for example required struct fields are missing from
+/// the JSON map or some number is too big to fit in the expected primitive
+/// type.
+///
+///
+pub fn from_value<'de, T>(value: &'de Value) -> Result<T, Error>
+where
+    T: Deserialize<'de>,
+{
+    T::deserialize(value)
+}
+
+impl<'de> Deserialize<'de> for Value {
+    /// Deserialize this value from a `Deserializer`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    ///
+    /// let v: Value = sonic_rs::from_str(r#"{"a": 1, "b": 2}"#).unwrap();
+    /// assert_eq!(v["a"], 1);
+    /// assert_eq!(v["b"], 2);
+    /// ```
+    ///
+    fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_newtype_struct(TOKEN, ValueVisitor)
+    }
+}
+
+pub(crate) const TOKEN: &str = "$sonic_rs::private::Value";
+
+pub(crate) struct ValueVisitor;
+
+impl<'de> Visitor<'de> for ValueVisitor {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a valid json")
+    }
+
+    fn visit_bytes<E>(self, value_binary: &[u8]) -> StdResult<Value, E>
+    where
+        E: de::Error,
+    {
+        // we pass the value from value_binary
+        unsafe {
+            assert!(
+                value_binary.len() == std::mem::size_of::<Value>(),
+                "invalid value size {}",
+                value_binary.len()
+            );
+            let mut dom: MaybeUninit<Value> = MaybeUninit::zeroed();
+            std::ptr::copy_nonoverlapping(
+                value_binary.as_ptr() as *const Value,
+                dom.as_mut_ptr(),
+                1,
+            );
+            Ok(dom.assume_init())
+        }
+    }
+}
+
+struct SeqRefDeserializer<'de> {
+    iter: slice::Iter<'de, Value>,
+}
+
+impl<'de> SeqRefDeserializer<'de> {
+    fn new(slice: &'de [Value]) -> Self {
+        SeqRefDeserializer { iter: slice.iter() }
+    }
+}
+
+impl<'de> SeqAccess<'de> for SeqRefDeserializer<'de> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapRefDeserializer<'de> {
+    iter: <&'de Object as IntoIterator>::IntoIter,
+    value: Option<&'de Value>,
+}
+
+impl<'de> MapRefDeserializer<'de> {
+    fn new(map: &'de Object) -> Self {
+        MapRefDeserializer {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for MapRefDeserializer<'de> {
+    type Error = Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some(value);
+                let key_de = MapKeyDeserializer { key };
+                seed.deserialize(key_de).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value.take() {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde::de::Error::custom("value is missing")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapKeyDeserializer<'de> {
+    key: &'de str,
+}
+
+macro_rules! deserialize_numeric_key {
+    ($method:ident) => {
+        deserialize_numeric_key!($method, deserialize_number);
+    };
+
+    ($method:ident, $using:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            let mut de =
+                crate::Deserializer::new(crate::reader::SliceRead::new(self.key.as_bytes()));
+            match de.parser.read.peek() {
+                Some(b'0'..=b'9' | b'-') => {}
+                _ => return Err(Error::syntax(ErrorCode::ExpectedNumericKey, b"", 0)),
+            }
+            let number = tri!(de.$using(visitor));
+            Ok(number)
+        }
+    };
+}
+
+impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(self.key)
+    }
+
+    deserialize_numeric_key!(deserialize_i8);
+    deserialize_numeric_key!(deserialize_i16);
+    deserialize_numeric_key!(deserialize_i32);
+    deserialize_numeric_key!(deserialize_i64);
+    deserialize_numeric_key!(deserialize_u8);
+    deserialize_numeric_key!(deserialize_u16);
+    deserialize_numeric_key!(deserialize_u32);
+    deserialize_numeric_key!(deserialize_u64);
+    // TODO: impl parsing f32
+    deserialize_numeric_key!(deserialize_f32);
+    deserialize_numeric_key!(deserialize_f64);
+    deserialize_numeric_key!(deserialize_i128, deserialize_i128);
+    deserialize_numeric_key!(deserialize_u128, deserialize_u128);
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.key == "true" {
+            visitor.visit_bool(true)
+        } else if self.key == "false" {
+            visitor.visit_bool(false)
+        } else {
+            Err(serde::de::Error::invalid_type(
+                Unexpected::Str(self.key),
+                &visitor,
+            ))
+        }
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Map keys cannot be null.
+        visitor.visit_some(self)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.key
+            .into_deserializer()
+            .deserialize_enum(name, variants, visitor)
+    }
+
+    forward_to_deserialize_any! {
+        char str string bytes byte_buf unit unit_struct seq tuple tuple_struct
+        map struct identifier ignored_any
+    }
+}
+
+fn visit_array_ref<'de, V>(array: &'de [Value], visitor: V) -> Result<V::Value, Error>
+where
+    V: Visitor<'de>,
+{
+    let len = array.len();
+    let mut deserializer = SeqRefDeserializer::new(array);
+    let seq = tri!(visitor.visit_seq(&mut deserializer));
+    let remaining = deserializer.iter.len();
+    if remaining == 0 {
+        Ok(seq)
+    } else {
+        Err(serde::de::Error::invalid_length(
+            len,
+            &"fewer elements in array",
+        ))
+    }
+}
+
+fn visit_object_ref<'de, V>(object: &'de Object, visitor: V) -> Result<V::Value, Error>
+where
+    V: Visitor<'de>,
+{
+    let len = object.len();
+    let mut deserializer = MapRefDeserializer::new(object);
+    let map = tri!(visitor.visit_map(&mut deserializer));
+    let remaining = deserializer.iter.len();
+    if remaining == 0 {
+        Ok(map)
+    } else {
+        Err(serde::de::Error::invalid_length(
+            len,
+            &"fewer elements in map",
+        ))
+    }
+}
+
+macro_rules! deserialize_number {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.as_ref() {
+                ValueRef::Number(n) => n.deserialize_any(visitor),
+                _ => Err(self.invalid_type(&visitor)),
+            }
+        }
+    };
+}
+
+impl Value {
+    #[cold]
+    fn invalid_type<E>(&self, exp: &dyn Expected) -> E
+    where
+        E: serde::de::Error,
+    {
+        serde::de::Error::invalid_type(self.unexpected(), exp)
+    }
+
+    #[cold]
+    fn unexpected(&self) -> Unexpected<'_> {
+        self.as_ref().unexpected()
+    }
+}
+
+impl<'a> ValueRef<'a> {
+    #[cold]
+    fn unexpected(&self) -> Unexpected<'a> {
+        match self {
+            ValueRef::Null => Unexpected::Unit,
+            ValueRef::Bool(b) => Unexpected::Bool(*b),
+            ValueRef::Number(n) => match n.n {
+                N::PosInt(u) => Unexpected::Unsigned(u),
+                N::NegInt(i) => Unexpected::Signed(i),
+                N::Float(f) => Unexpected::Float(f),
+            },
+            ValueRef::String(s) => Unexpected::Str(s),
+            ValueRef::Array(_) => Unexpected::Seq,
+            ValueRef::Object(_) => Unexpected::Map,
+        }
+    }
+}
+
+struct EnumRefDeserializer<'de> {
+    variant: &'de str,
+    value: Option<&'de Value>,
+}
+
+impl<'de> EnumAccess<'de> for EnumRefDeserializer<'de> {
+    type Error = Error;
+    type Variant = VariantRefDeserializer<'de>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = self.variant.into_deserializer();
+        let visitor = VariantRefDeserializer { value: self.value };
+        seed.deserialize(variant).map(|v| (v, visitor))
+    }
+}
+
+struct VariantRefDeserializer<'de> {
+    value: Option<&'de Value>,
+}
+
+impl<'de> VariantAccess<'de> for VariantRefDeserializer<'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Error> {
+        match self.value {
+            Some(value) => Deserialize::deserialize(value),
+            None => Ok(()),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.value {
+            Some(value) => seed.deserialize(value),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"newtype variant",
+            )),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value.map(|v| v.as_ref()) {
+            Some(ValueRef::Array(v)) => {
+                if v.is_empty() {
+                    visitor.visit_unit()
+                } else {
+                    visit_array_ref(v, visitor)
+                }
+            }
+            Some(other) => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"tuple variant",
+            )),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"tuple variant",
+            )),
+        }
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value.map(|v| v.as_ref()) {
+            Some(ValueRef::Object(v)) => visit_object_ref(v, visitor),
+            Some(other) => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"struct variant",
+            )),
+            None => Err(serde::de::Error::invalid_type(
+                Unexpected::UnitVariant,
+                &"struct variant",
+            )),
+        }
+    }
+}
+
+impl<'de> IntoDeserializer<'de, Error> for &'de Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+impl<'de> serde::Deserializer<'de> for &'de Value {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Null => visitor.visit_unit(),
+            ValueRef::Bool(v) => visitor.visit_bool(v),
+            ValueRef::Number(n) => n.deserialize_any(visitor),
+            ValueRef::String(v) => visitor.visit_borrowed_str(v),
+            ValueRef::Array(v) => visit_array_ref(v, visitor),
+            ValueRef::Object(v) => visit_object_ref(v, visitor),
+        }
+    }
+
+    deserialize_number!(deserialize_i8);
+    deserialize_number!(deserialize_i16);
+    deserialize_number!(deserialize_i32);
+    deserialize_number!(deserialize_i64);
+    deserialize_number!(deserialize_i128);
+    deserialize_number!(deserialize_u8);
+    deserialize_number!(deserialize_u16);
+    deserialize_number!(deserialize_u32);
+    deserialize_number!(deserialize_u64);
+    deserialize_number!(deserialize_u128);
+    deserialize_number!(deserialize_f32);
+    deserialize_number!(deserialize_f64);
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        let (variant, value) = match self.as_ref() {
+            ValueRef::Object(value) => {
+                let mut iter = value.into_iter();
+                let (variant, value) = match iter.next() {
+                    Some(v) => v,
+                    None => {
+                        return Err(serde::de::Error::invalid_value(
+                            Unexpected::Map,
+                            &"map with a single key",
+                        ));
+                    }
+                };
+                // enums are encoded in json as maps with a single key:value pair
+                if iter.next().is_some() {
+                    return Err(serde::de::Error::invalid_value(
+                        Unexpected::Map,
+                        &"map with a single key",
+                    ));
+                }
+                (variant, Some(value))
+            }
+            ValueRef::String(variant) => (variant, None),
+            other => {
+                return Err(serde::de::Error::invalid_type(
+                    other.unexpected(),
+                    &"string or map",
+                ));
+            }
+        };
+
+        visitor.visit_enum(EnumRefDeserializer { variant, value })
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        // deserialize value into RawValue
+        if name == crate::serde::raw::TOKEN {
+            return visitor.visit_map(crate::serde::raw::OwnedRawDeserializer {
+                raw_value: Some(self.to_string()),
+            });
+        }
+
+        let _ = name;
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Bool(v) => visitor.visit_bool(v),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::String(v) => visitor.visit_borrowed_str(v),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::String(v) => visitor.visit_borrowed_str(v),
+            ValueRef::Array(v) => visit_array_ref(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Null => visitor.visit_unit(),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_unit_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Array(v) => visit_array_ref(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Object(v) => visit_object_ref(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.as_ref() {
+            ValueRef::Array(v) => visit_array_ref(v, visitor),
+            ValueRef::Object(v) => visit_object_ref(v, visitor),
+            _ => Err(self.invalid_type(&visitor)),
+        }
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test_value_as_deserializer() {
+        // unimplemented!()
+    }
+}

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,0 +1,742 @@
+use super::array::{Array, DEFAULT_ARRAY_CAP};
+use super::object::Object;
+use crate::serde::number::N;
+use crate::util::arc::Arc;
+use crate::value::node::Value;
+use crate::value::object::DEFAULT_OBJ_CAP;
+use crate::value::shared::Shared;
+use crate::Number;
+use faststr::FastStr;
+use std::borrow::Cow;
+use std::cell::UnsafeCell;
+use std::convert::Into;
+use std::fmt::Debug;
+use std::mem::ManuallyDrop;
+use std::str::FromStr;
+
+impl From<Number> for Value {
+    /// Convert `Number` to a `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Number, Value, json};
+    ///
+    /// let x = Value::from(Number::from(7));
+    /// assert_eq!(x, json!(7));
+    /// ```
+    #[inline]
+    fn from(val: Number) -> Self {
+        let shared = get_shared();
+        match val.n {
+            N::PosInt(u) => Value::new_u64(u, shared),
+            N::NegInt(i) => Value::new_i64(i, shared),
+            N::Float(f) => unsafe { Value::new_f64_unchecked(f, shared) },
+        }
+    }
+}
+
+macro_rules! impl_from_integer {
+    ($($ty:ident),*) => {
+        $(
+            impl From<$ty> for Value {
+                fn from(val: $ty) -> Self {
+                    Into::<Number>::into(val).into()
+                }
+            }
+        )*
+    };
+    () => {};
+}
+
+impl_from_integer!(u8, u16, u32, u64, usize, i8, i16, i32, i64, isize);
+
+impl From<bool> for Value {
+    /// Convert `bool` to a boolean `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use sonic_rs::JsonValueTrait;
+    ///
+    /// let x: Value = true.into();
+    /// assert!(x.is_true());
+    /// ```
+    #[inline]
+    fn from(val: bool) -> Self {
+        Value::new_bool(val, get_shared())
+    }
+}
+
+macro_rules! impl_from_str {
+    () => {};
+    ($($ty:ident),*) => {
+        $(
+            impl From<&$ty> for Value {
+                /// Convert a string type into a string `Value`. The string will be copied into the `Value`.
+                ///
+                /// # Performance
+                ///
+                /// If it is `&'static str`, recommend to use [`Value::from_static_str`] and it is zero-copy.
+                ///
+                #[inline]
+                fn from(val: &$ty) -> Self {
+                    let (shared, is_root) = get_shared_or_new();
+                    let mut value = Value::copy_str(val, shared);
+                    if is_root {
+                        value.mark_root();
+                    }
+                    value
+                }
+            }
+        )*
+    };
+}
+
+impl_from_str!(String, str, FastStr);
+
+impl<'a> From<Cow<'a, str>> for Value {
+    /// Convert copy-on-write string to a string `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use std::borrow::Cow;
+    ///
+    /// let s1: Cow<str> = Cow::Borrowed("hello");
+    /// let x1 = Value::from(s1);
+    ///
+    /// let s2: Cow<str> = Cow::Owned("hello".to_string());
+    /// let x2 = Value::from(s2);
+    ///
+    /// assert_eq!(x1, x2);
+    /// ```
+    #[inline]
+    fn from(value: Cow<'a, str>) -> Self {
+        Into::<Self>::into(value.as_ref())
+    }
+}
+
+impl From<char> for Value {
+    /// Convert `char` to a string `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, json};
+    ///
+    /// let c: char = '😁';
+    /// let x: Value = c.into();
+    /// assert_eq!(x, json!("😁"));
+    /// ```
+    #[inline]
+    fn from(val: char) -> Self {
+        Into::<Self>::into(&val.to_string())
+    }
+}
+
+impl<T: Into<Value>> From<Vec<T>> for Value {
+    /// Convert a `Vec` to a `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, json};
+    ///
+    /// assert_eq!(Value::from(vec!["hi", "hello"]), json!(["hi", "hello"]));
+    ///
+    /// assert_eq!(Value::from(Vec::<i32>::new()), json!([]));
+    ///
+    /// assert_eq!(Value::from(vec![json!(null), json!("hi")]), json!([null, "hi"]));
+    ///
+    /// ```
+    #[inline]
+    fn from(val: Vec<T>) -> Self {
+        let shared = get_shared();
+        let is_root = shared.is_null();
+        if val.is_empty() {
+            return Value::new_array(shared, 0);
+        }
+
+        let mut array = if is_root {
+            let new_shared = Shared::new_ptr();
+            set_shared(new_shared);
+            Value::new_array(new_shared, val.len())
+        } else {
+            Value::new_array(shared, val.len())
+        };
+
+        for v in val {
+            // new create value will use the shared allocator.
+            array.append_value(Into::<Value>::into(v));
+        }
+        if is_root {
+            set_shared(std::ptr::null());
+            array.mark_root();
+        }
+        array
+    }
+}
+
+impl<T: Clone + Into<Value>, const N: usize> From<&[T; N]> for Value {
+    /// Convert a array reference `&[T; N]` to a `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, json};
+    ///
+    /// let x  = Value::from(&["hi", "hello"]);
+    ///
+    /// assert_eq!(x, json!(["hi", "hello"]));
+    ///
+    #[inline]
+    fn from(val: &[T; N]) -> Self {
+        Into::<Value>::into(val.as_ref())
+    }
+}
+
+impl<T: Clone + Into<Value>> From<&[T]> for Value {
+    /// Convert a slice `&[T]` to a `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, json};
+    ///
+    /// let x  = Value::from(&["hi", "hello"][..]);
+    ///
+    /// assert_eq!(x, json!(["hi", "hello"]));
+    ///
+    /// let x: &[i32] = &[];
+    /// assert_eq!(Value::from(x), json!([]));
+    /// ```
+    fn from(val: &[T]) -> Self {
+        let shared = get_shared();
+        let is_root = shared.is_null();
+        if val.is_empty() {
+            return Value::new_array(shared, 0);
+        }
+
+        let mut array = if is_root {
+            let new_shared = Shared::new_ptr();
+            set_shared(new_shared);
+            Value::new_array(new_shared, val.len())
+        } else {
+            Value::new_array(shared, val.len())
+        };
+        for v in val {
+            // new create value will use the shared allocator.
+            array.append_value(Into::<Value>::into(v.clone()));
+        }
+
+        if is_root {
+            array.mark_root();
+            set_shared(std::ptr::null());
+        }
+        array
+    }
+}
+
+impl From<()> for Value {
+    /// Convert `()` to `Value::Null`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use sonic_rs::JsonValueTrait;
+    ///
+    /// assert!(Value::from(()).is_null());
+    ///
+    /// ```
+    #[inline]
+    fn from(_: ()) -> Self {
+        let shared = get_shared();
+        Value::new_null(shared)
+    }
+}
+
+impl<T> From<Option<T>> for Value
+where
+    T: Into<Value>,
+{
+    /// Convert `Option` to `Value::Null`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use sonic_rs::JsonValueTrait;
+    ///
+    /// let u = Some(123);
+    /// let x = Value::from(u);
+    /// assert_eq!(x.as_i64(), u);
+    ///
+    /// let u = None;
+    /// let x: Value = u.into();
+    /// assert_eq!(x.as_i64(), u);
+    /// ```
+    #[inline]
+    fn from(opt: Option<T>) -> Self {
+        match opt {
+            None => Into::into(()),
+            Some(value) => Into::into(value),
+        }
+    }
+}
+
+impl FromStr for Value {
+    type Err = crate::Error;
+    /// Convert `&str` to `Value`. The `&str` will be copied into the `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use sonic_rs::JsonValueTrait;
+    /// use std::str::FromStr;
+    ///
+    /// let x = Value::from_str("string").unwrap();
+    /// assert_eq!(x.as_str().unwrap(), "string");
+    /// ```
+    /// # Performance
+    ///
+    /// If it is `&'static str`, recommend to use [`Value::from_static_str`].
+    ///
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Value::new_str_owned(s))
+    }
+}
+
+impl<'a, K: AsRef<str>, V: Clone + Into<Value>> FromIterator<(K, &'a V)> for Value {
+    /// Create a `Value` by collecting an iterator of key-value pairs.
+    /// The key will be copied into the `Value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, json, object};
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map = HashMap::new();
+    /// map.insert("sonic_rs", 40);
+    /// map.insert("json", 2);
+    ///
+    /// let x: Value = map.iter().collect();
+    /// assert_eq!(x, json!({"sonic_rs": 40, "json": 2}));
+    ///
+    /// let x: Value = Value::from_iter(&object!{"sonic_rs": 40, "json": 2});
+    /// assert_eq!(x, json!({"sonic_rs": 40, "json": 2}));
+    /// ```
+    ///
+    fn from_iter<T: IntoIterator<Item = (K, &'a V)>>(iter: T) -> Self {
+        let (shared, is_root) = get_shared_or_new();
+        if is_root {
+            set_shared(shared);
+        }
+
+        let mut obj = Value::new_object(shared, DEFAULT_OBJ_CAP);
+        for (k, v) in iter.into_iter() {
+            let k = Value::copy_str(k.as_ref(), shared);
+            // will create value use `shared` allocator
+            let v = v.clone().into();
+            obj.append_pair((k, v));
+        }
+
+        if is_root {
+            obj.mark_root();
+            set_shared(std::ptr::null());
+        }
+        obj
+    }
+}
+
+impl<T: Into<Value>> FromIterator<T> for Value {
+    /// Create a `Value` by collecting an iterator of array elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, json};
+    /// use std::iter::FromIterator;
+    ///
+    /// let v = std::iter::repeat(6).take(3);
+    /// let x: Value = v.collect();
+    /// assert_eq!(x, json!([6, 6, 6]));
+    ///
+    /// let x = Value::from_iter(vec!["sonic_rs", "json", "serde"]);
+    /// assert_eq!(x, json!(["sonic_rs", "json", "serde"]));
+    /// ```
+    ///
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let (shared, is_root) = get_shared_or_new();
+        if is_root {
+            set_shared(shared);
+        }
+
+        let mut arr = Value::new_array(shared, DEFAULT_ARRAY_CAP);
+        for v in iter.into_iter() {
+            // will create value use `shared` allocator
+            arr.append_value(v.into());
+        }
+
+        if is_root {
+            arr.mark_root();
+            set_shared(std::ptr::null());
+        }
+        arr
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+impl<T: Into<Value>> From<Vec<T>> for Array {
+    /// Convert a `Vec` to a `Array`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::value::Array;
+    /// use sonic_rs::array;
+    ///
+    /// let v = vec!["hi", "hello"];
+    /// let x: Array = v.into();
+    /// assert_eq!(x, array!["hi", "hello"]);
+    /// ```
+    #[inline]
+    fn from(val: Vec<T>) -> Self {
+        debug_assert!(get_shared().is_null(), "array should not be shared");
+        let value = Into::<Value>::into(val);
+        Array(value)
+    }
+}
+
+impl<T: Clone + Into<Value>, const N: usize> From<&[T; N]> for Array {
+    /// Convert a array `&[T; N]` to a `Array`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Array, array};
+    ///
+    /// let v = &["hi", "hello"];
+    /// let x: Array = v.into();
+    /// assert_eq!(x, array!["hi", "hello"]);
+    /// ```
+    ///
+    fn from(val: &[T; N]) -> Self {
+        debug_assert!(get_shared().is_null(), "array should not be shared");
+        let value = Into::<Value>::into(val.as_ref());
+        Array(value)
+    }
+}
+
+impl<T: Into<Value>> FromIterator<T> for Array {
+    /// Create a `Array` by collecting an iterator of array elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Array, json, array};
+    /// use std::iter::FromIterator;
+    ///
+    /// let v = std::iter::repeat(6).take(3);
+    /// let x: Array = v.collect();
+    /// assert_eq!(x, json!([6, 6, 6]));
+    ///
+    /// let x = Array::from_iter(vec!["sonic_rs", "json", "serde"]);
+    /// assert_eq!(x, array!["sonic_rs", "json", "serde"]);
+    /// ```
+    ///
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        debug_assert!(get_shared().is_null(), "array should not be shared");
+        let value = Value::from_iter(iter);
+        Array(value)
+    }
+}
+
+impl<T: Clone + Into<Value>> From<&[T]> for Array {
+    /// Convert a slice `&[T]` to a `Array`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::value::Array;
+    /// use sonic_rs::array;
+    ///
+    /// let v = &["hi", "hello"];
+    /// let x: Array = v.into();
+    /// assert_eq!(x, array!["hi", "hello"]);
+    /// ```
+    ///
+    fn from(val: &[T]) -> Self {
+        debug_assert!(get_shared().is_null(), "array should not be shared");
+        let value = Into::<Value>::into(val);
+        Array(value)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+impl<'a, K: AsRef<str>, V: Clone + Into<Value> + 'a> FromIterator<(K, &'a V)> for Object {
+    /// Create a `Object` by collecting an iterator of key-value pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Value, object, Object};
+    /// use std::collections::HashMap;
+    ///
+    /// let mut map = HashMap::new();
+    /// map.insert("sonic_rs", 40);
+    /// map.insert("json", 2);
+    ///
+    /// let x: Object = map.iter().collect();
+    /// assert_eq!(x, object!{"sonic_rs": 40, "json": 2});
+    ///
+    /// let x = Object::from_iter(&object!{"sonic_rs": 40, "json": 2});
+    /// assert_eq!(x, object!{"sonic_rs": 40, "json": 2});
+    /// ```
+    ///
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (K, &'a V)>>(iter: T) -> Self {
+        debug_assert!(get_shared().is_null(), "object should not be shared");
+        let value = Value::from_iter(iter);
+        Object(value)
+    }
+}
+
+impl<'a, T: Clone + Into<Value> + 'a> Extend<&'a T> for Array {
+    /// Extend a `Array` with the contents of an iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Array, array, json};
+    /// let mut arr = array![];
+    ///
+    /// // array extend from a slice &[i32]
+    /// arr.extend(&[1, 2, 3]);
+    /// assert_eq!(arr, array![1, 2, 3]);
+    ///
+    /// arr.extend(&Array::default());
+    /// assert_eq!(arr, array![1, 2, 3]);
+    ///
+    /// // array extend from other array
+    /// arr.extend(&array![4, 5, 6]);
+    /// assert_eq!(arr, array![1, 2, 3, 4, 5, 6]);
+    ///
+    /// ```
+    ///
+    #[inline]
+    fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
+        debug_assert!(
+            get_shared().is_null(),
+            "array extend should not use outer shared allocator"
+        );
+        let shared = self.0.check_shared();
+        set_shared(shared);
+        for v in iter {
+            // new create value will use `shared` allocator
+            self.push(v.clone().into());
+        }
+        set_shared(std::ptr::null());
+    }
+}
+
+impl<'a, K: AsRef<str> + ?Sized, V: Clone + Debug + Into<Value> + 'a> Extend<(&'a K, &'a V)>
+    for Object
+{
+    /// Extend a `Object` with the contents of an iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{Object, object, json, Value};
+    /// use std::collections::HashMap;
+    ///
+    /// let mut obj = object![];
+    /// let mut map: HashMap<&str, Value> ={
+    ///     let mut map = HashMap::new();
+    ///     map.insert("sonic", json!(40));
+    ///     map.insert("rs", json!(null));
+    ///     map
+    /// };
+    ///
+    /// obj.extend(&map);
+    /// assert_eq!(obj, object!{"sonic": 40, "rs": null});
+    ///
+    /// obj.extend(&object!{"object": [1, 2, 3]});
+    /// assert_eq!(obj, object!{"sonic": 40, "rs": null, "object": [1, 2, 3]});
+    ///
+    /// ```
+    ///
+    fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
+        debug_assert!(
+            get_shared().is_null(),
+            "object extend should not use outer shared allocator"
+        );
+        let shared = self.0.check_shared() as *const _;
+        set_shared(shared);
+        for (k, v) in iter {
+            let k = Value::copy_str(k.as_ref(), self.0.shared());
+            // new create value will use `shared` allocator
+            let mut v = v.clone().into();
+            v.unmark_root();
+            self.0.append_pair((k, v));
+        }
+        set_shared(std::ptr::null());
+    }
+}
+
+impl From<Array> for Value {
+    #[inline]
+    fn from(val: Array) -> Self {
+        val.0
+    }
+}
+
+impl From<Object> for Value {
+    #[inline]
+    fn from(val: Object) -> Self {
+        val.0
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+// We use a thread local to make the allocator can be used in whole `From` trait.
+thread_local! {
+    static SHARED: UnsafeCell<*const Shared> = const { UnsafeCell::new(std::ptr::null()) };
+}
+
+pub(crate) fn get_shared() -> *const Shared {
+    SHARED.with(|shared| unsafe { *shared.get() })
+}
+
+pub(crate) fn get_shared_or_new() -> (&'static Shared, bool) {
+    let shared = SHARED.with(|shared| unsafe { *shared.get() });
+    if shared.is_null() {
+        let arc = ManuallyDrop::new(Arc::new(Shared::new()));
+        (unsafe { &*arc.data_ptr() }, true)
+    } else {
+        (unsafe { &*shared }, false)
+    }
+}
+
+pub(crate) fn set_shared(new_shared: *const Shared) {
+    SHARED.with(|shared| unsafe { *((*shared).get()) = new_shared });
+}
+
+pub(crate) struct SharedCtxGuard {
+    old: *const Shared,
+}
+
+impl SharedCtxGuard {
+    /// assign `new_shared` into SharedCtx
+    pub(crate) fn assign(new_shared: *const Shared) -> Self {
+        let old = get_shared();
+        set_shared(new_shared);
+        Self { old }
+    }
+}
+
+impl Drop for SharedCtxGuard {
+    fn drop(&mut self) {
+        set_shared(self.old);
+    }
+}
+
+pub(crate) struct CheckCtxGuard {
+    is_root: bool,
+}
+
+impl CheckCtxGuard {
+    /// assign `new_shared` into SharedCtx
+    pub(crate) fn new() -> Self {
+        let old = get_shared();
+        if old.is_null() {
+            set_shared(Shared::new_ptr());
+            Self { is_root: true }
+        } else {
+            Self { is_root: false }
+        }
+    }
+}
+
+impl Drop for CheckCtxGuard {
+    fn drop(&mut self) {
+        if self.is_root {
+            set_shared(std::ptr::null());
+        }
+    }
+}
+#[cfg(test)]
+mod test {
+
+    use crate::array;
+    use crate::json;
+    use crate::object;
+    use crate::value::node::Value;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_from() {
+        let a1 = json!([1, 2, 3]);
+        let a2: Value = vec![1, 2, 3].into();
+        assert_eq!(a1, a2);
+        let v = Value::from(vec![json!("hi")]);
+        dbg!(&v);
+        assert_eq!(v, json!(["hi"]));
+    }
+
+    #[test]
+    fn test_extend_array() {
+        let mut a1 = array![1, 2, 3];
+        let mut b1 = a1.clone();
+
+        let a2 = vec![4, 5, 6];
+        let a3 = array![4, 5, 6];
+        a1.extend(&a2);
+        b1.extend(&a3);
+        assert_eq!(a1, b1);
+    }
+
+    #[test]
+    fn test_extend_object() {
+        let mut obj = object![];
+        let mut map: HashMap<&str, Value> = HashMap::new();
+
+        map.insert("sonic_rs", json!(40));
+        map.insert("json", "hi".into());
+        obj.extend(map.iter());
+    }
+
+    #[test]
+    fn test_from_iter() {
+        use crate::{json, Value};
+        use std::collections::HashMap;
+        use std::iter::FromIterator;
+
+        let mut map = HashMap::new();
+        map.insert("sonic_rs", 40);
+        map.insert("json", 2);
+
+        let x: Value = map.iter().collect();
+        assert_eq!(x, json!({"sonic_rs": 40, "json": 2}));
+
+        let v = std::iter::repeat(6).take(3);
+        let x1: Vec<_> = v.collect();
+        dbg!(x1);
+        let v = std::iter::repeat(6).take(3);
+        let x: Value = v.collect();
+        assert_eq!(x, json!([6, 6, 6]));
+
+        let x = Value::from_iter(vec!["sonic_rs", "json", "serde"]);
+        assert_eq!(x, json!(["sonic_rs", "json", "serde"]));
+    }
+}

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,83 +1,226 @@
-use crate::{lazyvalue::LazyValue, value::Value};
-use core::ops;
+use super::{node::Value, value_trait::JsonValueMutTrait};
+use crate::lazyvalue::LazyValue;
+use crate::util::private::Sealed;
+use crate::util::reborrow::DormantMutRef;
+use crate::value::from::SharedCtxGuard;
+use crate::value::object::DEFAULT_OBJ_CAP;
+use crate::value::shared::Shared;
+use crate::value::value_trait::JsonValueTrait;
+use std::convert::Into;
 
-pub trait Index: private::Sealed {
+impl<I> std::ops::Index<I> for Value
+where
+    I: Index,
+{
+    type Output = Value;
+
+    /// Index into an array `Value` using the syntax `value[0]` and index into an
+    /// object `Value` using the syntax `value["k"]`.
+    ///
+    /// Returns a null `Value` if the `Value` type does not match the index, or the
+    /// index does not exist in the array or object.
+    ///
+    /// For retrieving deeply nested values, you should have a look at the `Value::pointer` method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{json, pointer, JsonValueTrait};
+    ///
+    /// let data = json!({
+    ///     "x": {
+    ///         "y": ["z", "zz"]
+    ///     }
+    /// });
+    ///
+    /// assert_eq!(data["x"]["y"], json!(["z", "zz"]));
+    /// assert_eq!(data["x"]["y"][0], json!("z"));
+    ///
+    /// assert_eq!(data["a"], json!(null)); // returns null for undefined values
+    /// assert_eq!(data["a"]["b"], json!(null)); // does not panic
+    ///
+    /// // use pointer for retrieving nested values
+    /// assert_eq!(data.pointer(&pointer!["x", "y", 0]).unwrap(), &json!("z"));
+    /// ```
+
+    #[inline]
+    fn index(&self, index: I) -> &Value {
+        static NULL: Value = Value::new();
+        index.value_index_into(self).unwrap_or(&NULL)
+    }
+}
+
+impl<I: Index> std::ops::IndexMut<I> for Value {
+    /// Write the index of a mutable `Value`, and use the syntax `value[0] = ...`
+    /// in an array and `value["k"] = ...` in an object.
+    ///
+    /// If the index is a number, the value must be an array of length bigger
+    /// than the index. Indexing into a value that is not an array or an array
+    /// that is too small will panic.
+    ///
+    /// If the index is a string, the value must be an object or null which is
+    /// treated like an empty object. If the key is not already present in the
+    /// object, it will be inserted with a value of null. Indexing into a value
+    /// that is neither an object nor null will panic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use sonic_rs::json;
+    /// #
+    /// let mut data = json!({ "x": 0, "z": null });
+    ///
+    /// // replace an existing key
+    /// data["x"] = json!(1);
+    ///
+    /// // insert a new key
+    /// data["y"] = json!([1, 2, 3]);
+    ///
+    /// // replace an array value
+    /// data["y"][0] = json!(true);
+    ///
+    /// // inserted a deeply nested key
+    /// data["a"]["b"]["c"]["d"] = json!(true);
+    ///
+    /// //insert an key in a null value
+    /// data["z"]["zz"] = json!("insert in null");
+    ///
+    /// assert_eq!(data, json!({
+    ///   "x": 1,
+    ///   "y": [true, 2, 3],
+    ///   "a": { "b": {"c": {"d": true}}},
+    ///    "z": {"zz": "insert in null"}
+    /// }));
+    ///
+    /// ```
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut Value {
+        index.index_or_insert(self)
+    }
+}
+
+/// An indexing trait for immutable `sonic_rs::Value`.
+///
+pub trait Index: Sealed {
     /// Return None if the index is not already in the array or object.
     #[doc(hidden)]
-    fn value_index_into<'dom, 'v>(self, v: &'v Value<'dom>) -> Option<&'v Value<'dom>>;
+    fn value_index_into<'v>(&self, v: &'v Value) -> Option<&'v Value>;
 
     /// Return None if the index is not already in the array or object lazy_value.
     #[doc(hidden)]
-    fn lazyvalue_index_into<'de>(self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>>;
-}
+    fn lazyvalue_index_into<'de>(&self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>>;
 
-pub trait IndexMut: private::Sealed {
     /// Return None if the key is not already in the array or object.
     #[doc(hidden)]
-    fn index_into_mut<'dom, 'v>(self, v: &'v mut Value<'dom>) -> Option<&'v mut Value<'dom>>;
+    fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value>;
+
+    /// Panic if array index out of bounds. If key is not already in the object,
+    /// insert it with a value of null. Panic if Value is a type that cannot be
+    /// indexed into, except if Value is null then it can be treated as an empty
+    /// object.
+    #[doc(hidden)]
+    fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value;
 }
 
 impl Index for usize {
-    fn value_index_into<'dom, 'v>(self, v: &'v Value<'dom>) -> Option<&'v Value<'dom>> {
-        v.get_index(self)
+    fn value_index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+        if !v.is_array() {
+            return None;
+        }
+        v.get_index(*self)
     }
 
-    fn lazyvalue_index_into<'de>(self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>> {
-        v.get_index(self)
+    fn lazyvalue_index_into<'de>(&self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>> {
+        v.get_index(*self)
+    }
+
+    fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
+        if !v.is_array() {
+            return None;
+        }
+        v.get_index_mut(*self)
+    }
+
+    fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
+        let typ = v.get_type();
+        let len = v.len();
+        v.as_array_mut()
+            .unwrap_or_else(|| panic!("cannot access index in non-array value type {:?}", typ))
+            .0
+            .get_index_mut(*self)
+            .unwrap_or_else(|| panic!("index {} out of bounds (len: {})", *self, len))
     }
 }
 
-impl IndexMut for usize {
-    fn index_into_mut<'dom, 'v>(self, v: &'v mut Value<'dom>) -> Option<&'v mut Value<'dom>> {
-        v.get_index_mut(self)
-    }
-}
-
-macro_rules! impl_index {
+macro_rules! impl_str_index {
     ($($t: ty),*) => {
         $(
             impl Index for &$t {
-                fn value_index_into<'dom, 'v>(self, v: &'v Value<'dom>) -> Option<&'v Value<'dom>> {
-                    v.get_key(self)
+                fn value_index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+                    if !v.is_object() {
+                        return None;
+                    }
+                    v.get_key(*self)
                 }
 
-                fn lazyvalue_index_into<'de>(self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>> {
-                    v.get_key(self)
+                fn lazyvalue_index_into<'de>(&self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>> {
+                    v.get_key(*self)
                 }
-            }
 
-            impl IndexMut for &$t {
-                fn index_into_mut<'dom, 'v>(self, v: &'v mut Value<'dom>) -> Option<&'v mut Value<'dom>> {
-                    v.get_key_mut(self)
+                fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
+                    if !v.is_object() {
+                        return None;
+                    }
+                    v.get_key_mut(*self).map(|v| v.0)
+                }
+
+                fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
+                    let mut shared = v.shared_parts();
+                    if v.is_null() {
+                        if shared.is_null() {
+                            shared = Shared::new_ptr();
+                            *v = Value::new_object(shared, 8);
+                        } else {
+                            unsafe { std::ptr::write(v, Value::new_object(shared, DEFAULT_OBJ_CAP)) };
+                        }
+                    }
+
+                    let typ = v.get_type();
+                    let (obj, mut dormant_obj) = DormantMutRef::new(v);
+                    obj.as_object_mut()
+                        .expect(&format!("cannot access key in non-object value {:?}", typ))
+                        .0
+                        .get_key_mut(*self).map_or_else(|| {
+                            let o =  unsafe { dormant_obj.reborrow() };
+                            let _ = SharedCtxGuard::assign(shared);
+                            let inserted = o.append_pair((Into::<Value>::into((*self)), Value::new_null(shared)));
+                            &mut inserted.1
+                        }, |v| v.0)
                 }
             }
         )*
     };
 }
 
-impl_index!(str, String, faststr::FastStr);
+impl_str_index!(str, String, faststr::FastStr);
 
-// Prevent users from implementing the Index trait.
-mod private {
-    pub trait Sealed {}
-    impl Sealed for usize {}
-    impl Sealed for str {}
-    impl Sealed for std::string::String {}
-    impl Sealed for faststr::FastStr {}
-    impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
-}
-
-impl<'dom, I> ops::Index<I> for Value<'dom>
+impl<T> Index for &T
 where
-    I: Index,
+    T: ?Sized + Index,
 {
-    type Output = Value<'dom>;
+    fn value_index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+        (**self).value_index_into(v)
+    }
 
-    fn index(&self, index: I) -> &Value<'dom> {
-        // if not found, return NULL value
-        thread_local! {
-            pub static NULL: Value<'static> = const { Value::new_uinit() };
-        }
-        index.value_index_into(self).unwrap()
+    fn lazyvalue_index_into<'de>(&self, v: &'de LazyValue<'de>) -> Option<LazyValue<'de>> {
+        (**self).lazyvalue_index_into(v)
+    }
+
+    fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
+        (**self).index_into_mut(v)
+    }
+
+    fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
+        (**self).index_or_insert(v)
     }
 }

--- a/src/value/macros.rs
+++ b/src/value/macros.rs
@@ -1,0 +1,532 @@
+// The file is copied from `serde_json` and modified.
+
+/// Construct a `sonic_rs::Value` from a JSON literal.
+///
+/// ```
+/// # use sonic_rs::json;
+/// #
+/// let value = json!({
+///     "code": 200,
+///     "success": true,
+///     "payload": {
+///         "features": [
+///             "serde",
+///             "json"
+///         ],
+///         "homepage": null
+///     }
+/// });
+/// ```
+///
+/// Variables or expressions can be interpolated into the JSON literal. Any type
+/// interpolated into an array element or object value must implement Serde's
+/// `Serialize` trait, while any type interpolated into a object key must
+/// implement `AsRef<str>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `json!` macro will panic.
+///
+/// ```
+/// # use sonic_rs::json;
+/// #
+/// let code = 200;
+/// let features = vec!["sonic_rs", "json"];
+///
+/// let value = json!({
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         "features": features,
+///         features[0]: features[1]
+///     }
+/// });
+/// assert_eq!(value["code"], 200);
+/// assert_eq!(value["payload"]["features"][0], "sonic_rs");
+/// ```
+///
+/// Trailing commas are allowed inside both arrays and objects.
+///
+/// ```
+/// # use sonic_rs::json;
+/// #
+///
+/// let value = json!([
+///     "notice",
+///     "the",
+///     "trailing",
+///     "comma -->",
+/// ]);
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! json {
+    //////////////////////////////////////////////////////////////////////////
+    // The implementation of a static node. It will not create a shared allocator.
+    //
+    // Must be invoked as: json_internal!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+    (true) => {
+        $crate::value::node::Value::new_bool(true, std::ptr::null())
+    };
+
+    (false) => {
+        $crate::value::node::Value::new_bool(false, std::ptr::null())
+    };
+
+    (null) => {
+        $crate::value::node::Value::new_null(std::ptr::null())
+    };
+
+    ([]) => {
+        $crate::value::array::Array::new().into_value()
+    };
+
+    ({}) => {
+        $crate::value::object::Object::new().into_value()
+    };
+
+    // Hide distracting implementation details from the generated rustdoc.
+    ($($json:tt)+) => {
+        {
+            use $crate::value::value_trait::JsonValueTrait;
+            let shared = unsafe { &*$crate::value::shared::Shared::new_ptr() };
+            let mut value = json_internal!(shared, $($json)+);
+            if value.is_number() {
+                unsafe {
+                    drop(Box::from_raw(shared as *const _ as *mut $crate::value::shared::Shared));
+                }
+                value.mark_shared(std::ptr::null());
+            } else {
+                value.mark_root();
+            }
+            value
+        }
+    };
+}
+
+/// Construct a `sonic_rs::value::Array` from a JSON array literal.
+///
+/// ```
+/// use sonic_rs::array;
+/// use sonic_rs::json;
+/// use sonic_rs::JsonValueTrait; // tait for `is_null()`
+///
+/// let local = "foo";
+/// let array = array![null, local, true, false, 123,  "hello", 1 == 2, array![1, 2, 3], {"key": "value"}];
+/// assert!(array[0].is_null());
+/// assert_eq!(array[1].as_str(), Some("foo"));
+/// assert_eq!(array[array.len() - 2][0].as_u64(), Some(1));
+/// assert_eq!(array[array.len() - 1], json!({"key": "value"}));
+///
+/// ```
+///
+#[macro_export(local_inner_macros)]
+macro_rules! array {
+    () => {
+        $crate::value::Array::new()
+    };
+
+    ($($tt:tt)+) => {
+        {
+            let shared = unsafe { &*$crate::value::shared::Shared::new_ptr() };
+            let mut value = json_internal!(shared, [$($tt)+]);
+            value.mark_root();
+            value.into_array().expect("the literal is not a json array")
+        }
+    };
+}
+
+/// Construct a `sonic_rs::value::Object` from a JSON object literal.
+///
+/// ```
+/// # use sonic_rs::object;
+/// #
+/// let code = 200;
+/// let features = vec!["sonic_rs", "json"];
+///
+/// let object = object!{
+///     "code": code,
+///     "success": code == 200,
+///     "payload": {
+///         "features": features,
+///         features[0]: features[1]
+///     }
+/// };
+/// assert_eq!(object["code"], 200);
+/// assert_eq!(object["payload"]["features"][0], "sonic_rs");
+/// ```
+///
+#[macro_export(local_inner_macros)]
+macro_rules! object {
+    () => {
+        $crate::value::Object::new()
+    };
+
+    ($($tt:tt)+) => {
+        {
+            let shared = unsafe { &*$crate::value::shared::Shared::new_ptr() };
+            let mut value = json_internal!(shared, {$($tt)+});
+            value.mark_root();
+            value.into_object().expect("the literal is not a json object")
+        }
+    };
+}
+
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! json_internal {
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an array [...]. Produces a vec![...]
+    // of the elements.
+    //
+    // Must be invoked as: json_internal!(@array [] $($tt)*)
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done with trailing comma.
+    (@array $shared:expr, [$($elems:expr,)*]) => {
+        json_internal_array![$shared, $($elems)*]
+    };
+
+    // Done without trailing comma.
+    (@array $shared:expr, [$($elems:expr),*]) => {
+        json_internal_array![$shared, $($elems)*]
+    };
+
+    // Next element is `null`.
+    (@array $shared:expr, [$($elems:expr,)*] null $($rest:tt)*) => {
+        json_internal!(@array  $shared, [$($elems,)* json_internal!($shared, null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array $shared:expr, [$($elems:expr,)*] true $($rest:tt)*) => {
+        json_internal!(@array $shared, [$($elems,)* json_internal!($shared, true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array $shared:expr, [$($elems:expr,)*] false $($rest:tt)*) => {
+        json_internal!(@array $shared, [$($elems,)* json_internal!($shared, false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array $shared:expr, [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        json_internal!(@array $shared, [$($elems,)* json_internal!($shared, [$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array $shared:expr, [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        json_internal!(@array  $shared, [$($elems,)* json_internal!($shared, {$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array $shared:expr, [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        json_internal!(@array $shared, [$($elems,)* json_internal!($shared, $next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array $shared:expr, [$($elems:expr,)*] $last:expr) => {
+        json_internal!(@array $shared, [$($elems,)* json_internal!($shared, $last)])
+    };
+
+    // Comma after the most recent element.
+    (@array $shared:expr, [$($elems:expr),*] , $($rest:tt)*) => {
+        json_internal!(@array $shared, [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array $shared:expr, [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected)
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // TT muncher for parsing the inside of an object {...}. Each entry is
+    // inserted into the given map variable.
+    //
+    // Must be invoked as: json_internal!(@object $map () ($($tt)*) ($($tt)*))
+    //
+    // We require two copies of the input tokens so that we can match on one
+    // copy and trigger errors on the other copy.
+    //////////////////////////////////////////////////////////////////////////
+
+    // Done.
+    (@object $shared:expr, $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $shared:expr, $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let key: &str = ($($key)+).as_ref();
+        let pair: $crate::value::object::Pair = ($crate::value::node::Value::copy_str(key, $shared), $value);
+        let _ = $object.append_pair(pair);
+        json_internal!(@object $shared, $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $shared:expr, $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        json_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $shared:expr, $object:ident [$($key:tt)+] ($value:expr)) => {
+        let key: &str = ($($key)+).as_ref();
+        let pair: $crate::value::object::Pair = ($crate::value::node::Value::copy_str(key, $shared), $value);
+        let _ = $object.append_pair(pair);
+    };
+
+    // Next value is `null`.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, [$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, {$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, $value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        json_internal!(@object $shared, $object [$($key)+] (json_internal!($shared, $value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $shared:expr, $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        json_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $shared:expr, $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        json_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $shared:expr, $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        json_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $shared:expr, $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        json_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $shared:expr, $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $shared:expr, $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        json_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $shared:expr, $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $shared, $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    // The main implementation.
+    //
+    // Must be invoked as: json_internal!($($json)+)
+    //////////////////////////////////////////////////////////////////////////
+
+    ($shared:expr, true) => {
+        $crate::value::node::Value::new_bool(true, $shared)
+    };
+
+    ($shared:expr, false) => {
+        $crate::value::node::Value::new_bool(false, $shared)
+    };
+
+    ($shared:expr, null) => {
+        $crate::value::node::Value::new_null($shared)
+    };
+
+    ($shared:expr, []) => {
+        $crate::value::node::Value::new_array($shared, 0)
+    };
+
+    ($shared:expr, [ $($tt:tt)+ ]) => {
+        json_internal!(@array $shared, [] $($tt)+)
+    };
+
+    ($shared:expr, {}) => {
+        $crate::value::node::Value::new_object($shared, 0)
+    };
+
+    ($shared:expr, { $($tt:tt)+ }) => {
+        {
+            let mut obj_value = $crate::value::node::Value::new_object($shared, 0);
+            json_internal!(@object $shared, obj_value () ($($tt)+) ($($tt)+));
+            obj_value
+        }
+    };
+
+    // Any Serialize type: numbers, strings, struct literals, variables etc.
+    // Must be below every other rule.
+    ($shared:expr, $other:expr) => {
+        $crate::value::ser::to_value_in($shared.into(), &$other).unwrap()
+    };
+}
+
+// The json_internal macro above cannot invoke vec directly because it uses
+// local_inner_macros. A vec invocation there would resolve to $crate::vec.
+// Instead invoke vec here outside of local_inner_macros.
+#[macro_export(local_inner_macros)]
+#[doc(hidden)]
+macro_rules! json_internal_array {
+    ($shared:expr, $($content:tt)*) => {
+        {
+            let mut arr_value = $crate::value::node::Value::new_array($shared, 0);
+            $(
+                arr_value.append_value($content);
+            )*
+            arr_value
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_unexpected {
+    () => {};
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! json_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}
+
+#[cfg(test)]
+mod test {
+    use crate::value::value_trait::JsonValueTrait;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_json_memory() {
+        assert!(json!(true).is_static());
+        assert!(json!(false).is_static());
+        assert!(json!(null).is_static());
+        assert!(json!([]).is_static());
+        assert!(json!({}).is_static());
+        assert!(json!(123).is_static());
+        assert!(json!(1.23).is_static());
+        assert!(json!("123").is_root());
+        assert!(json!("").is_root());
+        assert!(json!({"1": 123}).is_root());
+        assert!(json!([[[]]]).is_root());
+    }
+
+    #[test]
+    fn test_json_macro() {
+        assert!(json!(true).is_true());
+        assert!(json!(false).is_false());
+        assert!(json!(null).is_null());
+        assert!(json!("123").is_str());
+        assert!(json!(vec![1]).is_array());
+        assert_eq!(json!(vec![1, 2, 3][2]).as_i64(), Some(3));
+
+        let buf = json!([1, 2, 3]);
+        let arr = json!([true, false, null, 1, 2, 3, "hi", 1 == 2, buf[1] == buf[2]]);
+        assert!(arr.is_array());
+        assert!(arr[arr.len() - 1].is_false());
+
+        let key = "i";
+        let key2 = "\"i\"";
+        let obj = json!({
+            "a": true,
+            "b": false,
+            "c": null,
+            "array": vec![1, 2, 3],
+            "map": ({
+                let mut map = HashMap::<String, String>::new();
+                map.insert("a".to_string(), "b".to_string());
+                map
+            }),
+            "f": 2.333,
+            "g": "hi",
+            "h": 1 == 2,
+            key: {
+                key2: [buf[1] == buf[2], 1],
+            },
+        });
+        assert!(obj.is_object());
+        assert!(obj["a"].is_true());
+        assert!(obj["array"][0].as_u64().unwrap() == 1);
+        assert!(obj["map"]["a"].as_str().unwrap() == "b");
+        assert!(obj[key][key2][1].as_u64().unwrap() == 1);
+
+        let obj = json!({
+            "a": { "b" : {"c": [[[]], {}, {}]} }
+        });
+        assert!(obj["a"]["b"]["c"][0][0].is_array());
+    }
+
+    #[test]
+    fn test_array_macro() {
+        let arr = array![];
+        assert!(arr.into_value().is_static());
+
+        let arr = array![true, false, null, 1, 2, 3, "hi", 1 == 2];
+        assert!(arr[arr.len() - 1].is_false());
+
+        let buf = array![1, 2, 3];
+        let arr = array![true, false, null, 1, 2, 3, "hi", 1 == 2, buf[1] == buf[2]];
+        assert!(arr[arr.len() - 1].is_false());
+    }
+
+    #[test]
+    fn test_object_macro() {
+        let obj = object! {};
+        assert!(obj.into_value().is_static());
+
+        let obj = object! {
+            "a": true,
+            "b": false,
+            "c": null,
+            "d": 1,
+            "e": 2,
+            "f": 3,
+            "g": "hi",
+            "h": 1 == 2,
+        };
+        assert!(obj["a"].is_true());
+
+        let buf = array![1, 2, 3];
+        let obj = object! {
+            "a": true,
+            "b": false,
+            "c": null,
+            "d": 1,
+            "e": 2,
+            "f": 3,
+            "g": "hi",
+            "h": 1 == 2,
+            "i": {
+                "i": [buf[1] == buf[2], 1],
+            },
+        };
+        assert!(obj["i"]["i"][1].as_u64().unwrap() == 1);
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -6,8 +6,7 @@ pub use value_trait::{JsonContainerTrait, JsonType, JsonValueMutTrait, JsonValue
 pub mod alloctor;
 pub mod array;
 pub mod de;
-mod from;
-pub mod index;
+pub(crate) mod from;
 pub mod shared;
 #[macro_use]
 mod macros;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,12 +1,27 @@
-mod index;
-mod node;
-mod value_trait;
-
 pub use crate::RawValue;
-pub use index::{Index, IndexMut};
-pub(crate) use node::TOKEN;
-pub use node::{
-    dom_from_slice, dom_from_slice_unchecked, dom_from_str, Array, ArrayMut, Document, Object,
-    ObjectMut, Value, ValueMut,
-};
-pub use value_trait::{JsonType, JsonValue};
+pub mod node;
+pub use node::{Value, ValueRef};
+
+pub use value_trait::{JsonContainerTrait, JsonType, JsonValueMutTrait, JsonValueTrait};
+pub mod alloctor;
+pub mod array;
+pub mod de;
+mod from;
+pub mod index;
+pub mod shared;
+#[macro_use]
+mod macros;
+pub mod object;
+mod partial_eq;
+pub mod ser;
+pub mod value_trait;
+pub use array::Array;
+pub use object::Object;
+mod tryfrom;
+
+pub use ser::to_value;
+
+pub use de::from_value;
+
+const MAX_STR_SIZE: usize = u32::MAX as usize;
+const PTR_BITS: usize = 48;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -4,6 +4,7 @@ mod value_trait;
 
 pub use crate::RawValue;
 pub use index::{Index, IndexMut};
+pub(crate) use node::TOKEN;
 pub use node::{
     dom_from_slice, dom_from_slice_unchecked, dom_from_str, Array, ArrayMut, Document, Object,
     ObjectMut, Value, ValueMut,

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -43,8 +43,9 @@ use std::str::from_utf8_unchecked;
 /// let v1 = json!({"a": 123});
 /// let v2: Value = sonic_rs::from_str(r#"{"a": 123}"#).unwrap();
 /// let v3 = {
-///     let map = HashMap::new();
-///     map.insert("a", 123);
+///     use std::collections::HashMap;
+///     let mut map: HashMap<&str, i32> = HashMap::new();
+///     map.insert(&"a", 123);
 ///     sonic_rs::to_value(&map).unwrap()
 /// };
 ///

--- a/src/value/object.rs
+++ b/src/value/object.rs
@@ -7,12 +7,33 @@ use crate::util::reborrow::DormantMutRef;
 use crate::value::node::Value;
 use std::marker::PhantomData;
 
-/// Represents the JSON object. It is a key-value array. Its order is as same as origin JSON.
+/// Represents the JSON object. The inner implement is a key-value array. Its order is as same as origin JSON.
 ///
-/// The key is not sorted and the find operation is O(n). If you are hea Recommend to use `BTreeMap<String, Value>` or `HashMap<String, Value>` instead.
+/// # Examples
+/// ```
+/// use sonic_rs::{from_str, Obejct};
+///
+/// let mut obj: Object = from_str(r#"{"a": 1, "b": true, "c": null}"#).unwrap();
+///
+/// assert_eq!(obj["a"], 1);
+/// assert_eq!(obj.insert(&"d", "e"), None);
+/// assert_eq!(obj["d"], "e");
+/// assert_eq!(obj.len(), 3); // allow duplicated keys
+/// ```
 ///
 /// # Warning
-/// `Object` is allowed to have duplicated keys. If you want to use it as a map, recommend to use `BTreeMap<String, Value>` or `HashMap<String, Value>` instead.
+/// The key in `Object` is not sorted and the `get` operation is O(n). And `Object` is allowed to have duplicated keys.
+///
+/// # Examples
+/// ```
+/// use sonic_rs::{from_str, Object};
+///
+/// let obj: Object = from_str(r#"{"a": 1, "a": true, "a": null}"#).unwrap();
+///
+/// assert_eq!(obj["a"], 1);
+/// assert_eq!(obj.len(), 3); // allow duplicated keys
+/// ```
+/// If you care about that, recommend to use `HashMap` or `BTreeMap` instead. The parse performance is slower than `Object`.
 ///
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[repr(transparent)]

--- a/src/value/object.rs
+++ b/src/value/object.rs
@@ -1,6 +1,6 @@
-use super::from::SharedCtxGuard;
 use super::node::replace_value;
 use super::shared::Shared;
+use super::shared::SharedCtxGuard;
 use super::value_trait::JsonValueTrait;
 use crate::serde::tri;
 use crate::util::reborrow::DormantMutRef;
@@ -11,14 +11,14 @@ use std::marker::PhantomData;
 ///
 /// # Examples
 /// ```
-/// use sonic_rs::{from_str, Obejct};
+/// use sonic_rs::{from_str, Object};
 ///
 /// let mut obj: Object = from_str(r#"{"a": 1, "b": true, "c": null}"#).unwrap();
 ///
 /// assert_eq!(obj["a"], 1);
 /// assert_eq!(obj.insert(&"d", "e"), None);
 /// assert_eq!(obj["d"], "e");
-/// assert_eq!(obj.len(), 3); // allow duplicated keys
+/// assert_eq!(obj.len(), 4);
 /// ```
 ///
 /// # Warning

--- a/src/value/object.rs
+++ b/src/value/object.rs
@@ -1,0 +1,981 @@
+use super::from::SharedCtxGuard;
+use super::node::replace_value;
+use super::shared::Shared;
+use super::value_trait::JsonValueTrait;
+use crate::serde::tri;
+use crate::util::reborrow::DormantMutRef;
+use crate::value::node::Value;
+use std::marker::PhantomData;
+
+/// Represents the JSON object. It is a key-value array. Its order is as same as origin JSON.
+///
+/// The key is not sorted and the find operation is O(n). If you are hea Recommend to use `BTreeMap<String, Value>` or `HashMap<String, Value>` instead.
+///
+/// # Warning
+/// `Object` is allowed to have duplicated keys. If you want to use it as a map, recommend to use `BTreeMap<String, Value>` or `HashMap<String, Value>` instead.
+///
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[repr(transparent)]
+pub struct Object(pub(crate) Value);
+
+impl Default for Object {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[doc(hidden)]
+pub type Pair = (Value, Value);
+
+pub(crate) const DEFAULT_OBJ_CAP: usize = 4;
+
+impl Object {
+    /// Returns the inner `Value`.
+    ///
+    #[inline]
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+
+    /// Create a new empty object.
+    ///
+    #[inline]
+    pub const fn new() -> Object {
+        let value = Value {
+            meta: super::node::Meta::new(super::node::ROOT_OBJECT, std::ptr::null()),
+            data: super::node::Data {
+                achildren: std::ptr::null_mut(),
+            },
+        };
+        Object(value)
+    }
+
+    /// Create a new empty object with capacity.
+    ///
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut v = Self::new();
+        v.0.reserve::<Pair>(capacity);
+        v
+    }
+
+    /// Clear the object, make it as empty but keep the allocated memory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{json, object};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.clear();
+    /// assert!(obj.is_empty());
+    /// assert!(obj.capacity() >= 3);
+    /// ```
+    ///
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the capacity of the object.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{json, object};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.insert(&"d", "e");
+    /// assert_eq!(obj.get(&"d").unwrap(), "e");
+    /// assert_eq!(obj.get(&"f"), None);
+    /// assert_eq!(obj.get(&"a").unwrap(), 1);
+    /// ```
+    ///
+    #[inline]
+    pub fn get<Q: AsRef<str>>(&self, key: &Q) -> Option<&Value> {
+        self.0.get_key(key.as_ref())
+    }
+
+    /// Returns `true` if the map contains a value for the specified key.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.insert(&"d", "e");
+    /// assert_eq!(obj.contains_key(&"d"), true);
+    /// assert_eq!(obj.contains_key(&"a"), true);
+    /// assert_eq!(obj.contains_key(&"e"), false);
+    /// ```
+    ///
+    #[inline]
+    pub fn contains_key<Q: AsRef<str>>(&self, key: &Q) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// Returns a mutable reference to the value corresponding to the key.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.insert(&"d", "e");
+    ///
+    /// *(obj.get_mut(&"d").unwrap()) = "f".into();
+    /// assert_eq!(obj.contains_key(&"d"), true);
+    /// assert_eq!(obj["d"], "f");
+    /// ```
+    ///
+    #[inline]
+    pub fn get_mut<Q: AsRef<str>>(&mut self, key: &Q) -> Option<&mut Value> {
+        self.0.get_key_mut(key.as_ref()).map(|v| v.0)
+    }
+
+    /// Returns the key-value pair corresponding to the supplied key.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.insert(&"d", "e");
+    ///
+    /// assert_eq!(obj.get_key_value(&"d").unwrap(), ("d", &Value::from("e")));
+    /// assert_eq!(obj.get_key_value(&"a").unwrap(), ("a", &Value::from(1)));
+    /// assert_eq!(obj.get_key_value(&"e"), None);
+    /// ```
+    ///
+    #[inline]
+    pub fn get_key_value<Q: AsRef<str>>(&self, key: &Q) -> Option<(&str, &Value)> {
+        self.0.get_key_value(key.as_ref())
+    }
+
+    /// Inserts a key-value pair into the object. The `Value` is converted from `V`.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// If the object did not have this key present, [`None`] is returned.
+    ///
+    /// If the object did have this key present, the value is updated, and the old
+    /// value is returned. The key is not updated, though; this matters for
+    /// types that can be `==` without being identical. See the [module-level
+    /// documentation] for more.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, json, Value};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// assert_eq!(obj.len(), 3);
+    /// assert_eq!(obj.insert(&"d", "e"), None);
+    /// assert_eq!(obj.len(), 4);
+    /// assert_eq!(obj["d"], "e");
+    /// assert_eq!(obj.insert(&"d", "f").unwrap(), "e");
+    /// assert_eq!(obj["d"], "f");
+    /// assert_eq!(obj.len(), 4);
+    /// assert_eq!(obj.insert(&"d", json!("h")).unwrap(), "f");
+    /// assert_eq!(obj["d"], "h");
+    /// assert_eq!(obj.insert(&"i", Value::from("j")), None);
+    /// assert_eq!(obj.len(), 5);
+    /// ```
+    ///
+    #[inline]
+    pub fn insert<K: AsRef<str>, V: Into<Value>>(&mut self, key: &K, value: V) -> Option<Value> {
+        match self.entry(key) {
+            Entry::Occupied(mut entry) => Some(entry.insert(value)),
+            Entry::Vacant(entry) => {
+                entry.insert(value);
+                None
+            }
+        }
+    }
+
+    /// Removes a key from the object, returning the value at the key if the key
+    /// was previously in the object.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// assert_eq!(obj.remove(&"d"), None);
+    /// assert_eq!(obj.remove(&"a").unwrap(), 1);
+    /// ```
+    ///
+    #[inline]
+    pub fn remove<Q: AsRef<str>>(&mut self, key: &Q) -> Option<Value> {
+        self.0.remove_key(key.as_ref())
+    }
+
+    /// Removes a key from the object, returning the stored key and value if the
+    /// key was previously in the obj.
+    ///
+    /// The key may be [`AsRef<str>`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object};
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// assert_eq!(obj.remove_entry(&"d"), None);
+    /// let (key, val) = obj.remove_entry(&"a").unwrap();
+    /// assert_eq!(key, "a");
+    /// assert_eq!(val, 1);
+    /// ```
+    ///
+    #[inline]
+    pub fn remove_entry<'k, Q: AsRef<str>>(&mut self, key: &'k Q) -> Option<(&'k str, Value)> {
+        self.0.remove_key(key.as_ref()).map(|v| (key.as_ref(), v))
+    }
+
+    /// Returns the number of key-value paris in the object.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the object contains no key-value pairs.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an immutable iterator over the key-value pairs of the object.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Iter(self.0.iter::<Pair>())
+    }
+
+    /// Returns an mutable iterator over  the key-value pairs of the object.
+    #[inline]
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        IterMut(self.0.iter_mut::<Pair>())
+    }
+
+    /// Gets the given key's corresponding entry in the object for in-place manipulation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    ///
+    /// let mut obj = object!{};
+    ///
+    /// for i in 0..10 {
+    ///     obj.entry(&i.to_string()).or_insert(1);
+    /// }
+    ///
+    /// for i in 0..10 {
+    ///     obj.entry(&i.to_string()).and_modify(|v| *v = Value::from(i + 1));
+    /// }
+    ///
+    /// assert_eq!(obj[&"1"], 2);
+    /// assert_eq!(obj[&"2"], 3);
+    /// assert_eq!(obj[&"3"], 4);
+    /// assert_eq!(obj.get(&"10"), None);
+    /// ```
+    ///
+    #[inline]
+    pub fn entry<'a, Q: AsRef<str>>(&'a mut self, key: &Q) -> Entry<'a> {
+        let (obj, mut dormant_obj) = DormantMutRef::new(self);
+        match obj.0.get_key_mut(key.as_ref()) {
+            None => {
+                // check flat
+                let obj_re = unsafe { dormant_obj.reborrow() };
+                if obj_re.0.is_static() {
+                    obj_re.0.mark_shared(Shared::new_ptr());
+                    obj_re.0.mark_root();
+                }
+                let shared = obj_re.0.shared();
+                let key = Value::copy_str(key.as_ref(), shared);
+                Entry::Vacant(VacantEntry {
+                    key,
+                    dormant_obj,
+                    _marker: PhantomData,
+                })
+            }
+            Some((handle, offset)) => {
+                Entry::Occupied(OccupiedEntry::new(handle, offset, dormant_obj))
+            }
+        }
+    }
+
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` for which `f(&k, &mut v)` returns `false`.
+    /// The elements are visited in unsorted (and unspecified) order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::object;
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.retain(|key, _| key == "a");
+    /// assert_eq!(obj.len(), 1);
+    /// assert_eq!(obj["a"], 1);
+    /// ```
+    #[inline]
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&str, &mut Value) -> bool,
+    {
+        if self.is_empty() {
+            return;
+        }
+        let start: *mut Pair = unsafe { self.0.children_mut_ptr::<Pair>() };
+        let mut cur = start;
+        for (k, v) in self.0.iter_mut::<Pair>() {
+            let key = k.as_str().unwrap();
+            if f(key, v) {
+                if !std::ptr::eq(k, cur as *mut Value) {
+                    unsafe { std::ptr::copy_nonoverlapping((k as *mut Value).cast(), cur, 1) };
+                }
+                cur = unsafe { cur.add(1) };
+            } else {
+                // drop the old value
+                v.take();
+            }
+        }
+        unsafe {
+            let new_len = cur.offset_from(start) as usize;
+            self.0.set_len(new_len);
+        }
+    }
+
+    /// Moves all elements from other into self, leaving other empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, json};
+    ///
+    /// let mut a = object!{};
+    /// let mut b = object!{"a": null, "b": 1};
+    /// a.append(&mut b);
+    ///
+    /// assert_eq!(a, object!{"a": null, "b": 1});
+    /// assert!(b.is_empty());
+    /// ```
+    #[inline]
+    pub fn append(&mut self, other: &mut Self) {
+        while let Some((k, v)) = other.0.pop_pair() {
+            self.0.append_pair((k, v));
+        }
+    }
+
+    /// Reserves capacity for at least additional more elements to be inserted in the given.
+    ///
+    /// # Examples
+    /// ```
+    /// use sonic_rs::object;
+    /// let mut obj = object!{};
+    /// obj.reserve(1);
+    /// assert!(obj.capacity() >= 1);
+    ///
+    /// obj.reserve(10);
+    /// assert!(obj.capacity() >= 10);
+    /// ```
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve::<Pair>(additional);
+    }
+}
+
+/// A view into a single occupied location in a `Object`.
+pub struct OccupiedEntry<'a> {
+    handle: &'a mut Value,
+    offset: usize,
+    dormant_obj: DormantMutRef<'a, Object>,
+    _marker: PhantomData<&'a mut Pair>,
+}
+
+impl<'a> OccupiedEntry<'a> {
+    /// Gets a reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    ///
+    /// if let Entry::Occupied(entry) = obj.entry(&"a") {
+    ///     assert_eq!(entry.get(), 1);
+    /// }
+    ///
+    /// if let Entry::Occupied(entry) = obj.entry(&"b") {
+    ///     assert_eq!(entry.get(), true);
+    /// }
+    ///
+    /// ```
+    #[inline]
+    pub fn get(&self) -> &Value {
+        self.handle
+    }
+
+    /// Gets a mutable reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.insert(&"a", Value::from("hello"));
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"a") {
+    ///     assert_eq!(entry.get_mut(), &Value::from("hello"));
+    /// }
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"b") {
+    ///     assert_eq!(entry.get_mut(), &true);
+    /// }
+    /// dbg!(&obj);
+    /// ```
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut Value {
+        self.handle
+    }
+
+    /// Converts the entry into a mutable reference to its value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    /// obj.insert(&"a", Value::from("hello"));
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"a") {
+    ///     let vref = entry.into_mut();
+    ///     assert_eq!(vref, &mut Value::from("hello"));
+    ///     *vref = Value::from("world");
+    /// }
+    ///
+    /// assert_eq!(obj["a"], "world");
+    /// ```
+    #[inline]
+    pub fn into_mut(self) -> &'a mut Value {
+        self.handle
+    }
+
+    /// Sets the value of the entry, and returns the entry's old value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::object;
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"a") {
+    ///     assert_eq!(entry.insert("hello"), 1);
+    /// }
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"a") {
+    ///     assert_eq!(entry.insert("world"), "hello");
+    /// }
+    ///
+    /// ```
+    #[inline]
+    pub fn insert<T: Into<Value>>(&mut self, val: T) -> Value {
+        let obj = unsafe { self.dormant_obj.reborrow() };
+        let val = {
+            let _ = SharedCtxGuard::assign(obj.0.shared_parts());
+            val.into()
+        };
+        replace_value(self.handle, val)
+    }
+
+    /// Takes the value out of the entry, and returns it.
+    ///
+    /// # Examples
+    /// ```
+    /// use sonic_rs::{object, Value};
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"a": 1, "b": true, "c": null};
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"a") {
+    ///     assert_eq!(entry.remove(), 1);
+    /// }
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"b") {
+    ///     assert_eq!(entry.remove(), true);
+    /// }
+    ///
+    /// if let Entry::Occupied(mut entry) = obj.entry(&"c") {
+    ///     assert_eq!(entry.remove(), Value::default());
+    /// }
+    /// assert!(obj.is_empty());
+    /// ```
+    #[inline]
+    pub fn remove(mut self) -> Value {
+        let obj = unsafe { self.dormant_obj.reborrow() };
+        let (_, val) = obj.0.remove_pair_index(self.offset);
+        val
+    }
+
+    #[inline]
+    pub(crate) fn new(
+        handle: &'a mut Value,
+        offset: usize,
+        dormant_obj: DormantMutRef<'a, Object>,
+    ) -> Self {
+        Self {
+            handle,
+            offset,
+            dormant_obj,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// A view into a vacant entry in a `Object`.
+pub struct VacantEntry<'a> {
+    pub(super) key: Value,
+    pub(super) dormant_obj: DormantMutRef<'a, Object>,
+    pub(super) _marker: PhantomData<&'a mut Pair>,
+}
+
+impl<'a> VacantEntry<'a> {
+    /// Insert a value into the vacant entry and return a mutable reference to it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::object;
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{};
+    ///
+    /// if let Entry::Vacant(entry) = obj.entry(&"hello") {
+    ///    assert_eq!(entry.insert(1), &1);
+    /// }
+    /// assert_eq!(obj.get(&"hello").unwrap(), 1);
+    /// ```
+    ///
+    pub fn insert<T: Into<Value>>(self, val: T) -> &'a mut Value {
+        let obj = unsafe { self.dormant_obj.awaken() };
+        obj.reserve(1);
+        let val = {
+            let _ = SharedCtxGuard::assign(obj.0.shared_parts());
+            val.into()
+        };
+        let pair = obj.0.append_pair((self.key, val));
+        &mut pair.1
+    }
+
+    /// Get the key of the vacant entry.
+    pub fn key(&self) -> &str {
+        self.key.as_str().unwrap()
+    }
+}
+
+/// A view into a single entry in a map, which may either be vacant or occupied.
+pub enum Entry<'a> {
+    /// A vacant Entry.
+    Vacant(VacantEntry<'a>),
+    /// An occupied Entry.
+    Occupied(OccupiedEntry<'a>),
+}
+
+impl<'a> Entry<'a> {
+    /// Ensures a value is in the entry by inserting the default if empty,
+    /// Example:
+    /// ```rust
+    ///  use sonic_rs::object;
+    ///
+    /// let mut obj = object!{};
+    /// obj.entry(&"hello").or_insert(1);
+    /// assert_eq!(obj.get(&"hello").unwrap(), 1);
+    ///
+    /// obj.entry(&"hello").or_insert(2);
+    /// assert_eq!(obj.get(&"hello").unwrap(), 1);
+    /// ```
+    #[inline]
+    pub fn or_insert<T: Into<Value>>(self, default: T) -> &'a mut Value {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the result of the default function if empty,
+    /// Example:
+    /// ```rust
+    /// use sonic_rs::Object;
+    /// let mut obj = Object::new();
+    /// obj.entry(&"hello").or_insert_with(|| 1.into() );
+    /// assert_eq!(obj.get(&"hello").unwrap(), 1);
+    ///
+    /// obj.entry(&"hello").or_insert_with(|| 2.into() );
+    /// assert_eq!(obj.get(&"hello").unwrap(), 1);
+    /// ```
+    #[inline]
+    pub fn or_insert_with<F: FnOnce() -> Value>(self, default: F) -> &'a mut Value {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(default()),
+        }
+    }
+
+    /// Return the key of the entry.
+    #[inline]
+    pub fn key(&self) -> &str {
+        match self {
+            Entry::Occupied(entry) => entry.handle.as_str().unwrap(),
+            Entry::Vacant(entry) => entry.key(),
+        }
+    }
+
+    /// Provides in-place mutable access to an occupied entry before any potential inserts into the object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::object;
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"a": 0, "b": true, "c": null};
+    /// obj.entry(&"a").and_modify(|v| *v = 2.into());
+    /// assert_eq!(obj.get(&"a").unwrap(), 2);
+    ///
+    /// obj.entry(&"a").and_modify(|v| *v = 2.into()).and_modify(|v| *v = 3.into());
+    /// assert_eq!(obj.get(&"a").unwrap(), 3);
+    ///
+    /// obj.entry(&"d").and_modify(|v| *v = 3.into());
+    /// assert_eq!(obj.get(&"d"), None);
+    ///
+    /// obj.entry(&"d").and_modify(|v| *v = 3.into()).or_insert(4);
+    /// assert_eq!(obj.get(&"d").unwrap(), 4);
+    /// ```
+    ///
+    #[inline]
+    pub fn and_modify<F: FnOnce(&mut Value)>(self, f: F) -> Self {
+        match self {
+            Entry::Occupied(entry) => {
+                f(entry.handle);
+                Entry::Occupied(entry)
+            }
+            Entry::Vacant(entry) => Entry::Vacant(entry),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting the default value if empty, and returns a mutable reference to the value in the entry.
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    /// use sonic_rs::value::object::Entry;
+    ///
+    /// let mut obj = object!{"c": null};    
+    /// assert_eq!(obj.entry(&"a").or_default(), &Value::default());
+    /// assert_eq!(obj.entry(&"d").or_default(), &Value::default());
+    /// ```
+    #[inline]
+    pub fn or_default(self) -> &'a mut Value {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Value::default()),
+        }
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    /// This method allows for generating key-derived values for insertion by providing the default
+    /// function a reference to the key that was moved during the `.entry(key)` method call.
+    ///
+    /// The reference to the moved key is provided so that cloning or copying the key is
+    /// unnecessary, unlike with `.or_insert_with(|| ... )`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::{object, Value};
+    ///
+    /// let mut obj = object!{"c": null};
+    ///
+    /// obj.entry(&"a").or_insert_with_key(|key | Value::from(key.len()));
+    /// assert_eq!(obj.get(&"a").unwrap(), 1);
+    ///
+    /// obj.entry(&"b").or_insert_with_key(|key | Value::from(key));
+    /// assert_eq!(obj.get(&"b").unwrap(), "b");
+    /// ```
+    #[inline]
+    pub fn or_insert_with_key<F>(self, default: F) -> &'a mut Value
+    where
+        F: FnOnce(&str) -> Value,
+    {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(mut entry) => {
+                let obj = unsafe { entry.dormant_obj.reborrow() };
+                let value = {
+                    let _ = SharedCtxGuard::assign(obj.0.shared_parts());
+                    default(entry.key())
+                };
+                entry.insert(value)
+            }
+        }
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+use std::iter::FusedIterator;
+use std::slice;
+
+macro_rules! impl_entry_iter {
+    (($name:ident $($generics:tt)*): $item:ty) => {
+        impl $($generics)* Iterator for $name $($generics)* {
+            type Item = $item;
+
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next().map(|(k, v)| (k.as_str().unwrap(), v))
+            }
+        }
+
+        impl $($generics)* DoubleEndedIterator for $name $($generics)* {
+            #[inline]
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.0.next_back().map(|(k, v)| (k.as_str().unwrap(), v))
+            }
+        }
+
+        impl $($generics)* ExactSizeIterator for $name $($generics)* {
+            #[inline]
+            fn len(&self) -> usize {
+                self.0.len()
+            }
+        }
+
+        impl $($generics)* FusedIterator for $name $($generics)* {}
+    };
+}
+
+/// An iterator over the entries of a `Object`.
+pub struct Iter<'a>(slice::Iter<'a, (Value, Value)>);
+impl_entry_iter!((Iter<'a>): (&'a str, &'a Value));
+
+/// A mutable iterator over the entries of a `Object`.
+pub struct IterMut<'a>(slice::IterMut<'a, (Value, Value)>);
+impl_entry_iter!((IterMut<'a>): (&'a str, &'a mut Value));
+
+/// An iterator over the keys of a `Object`.
+pub struct Keys<'a>(Iter<'a>);
+
+impl<'a> Iterator for Keys<'a> {
+    type Item = &'a str;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, _)| k)
+    }
+}
+
+impl<'a> DoubleEndedIterator for Keys<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(|(k, _)| k)
+    }
+}
+
+impl<'a> ExactSizeIterator for Keys<'a> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<'a> FusedIterator for Keys<'a> {}
+
+macro_rules! impl_value_iter {
+    (($name:ident $($generics:tt)*): $item:ty) => {
+        impl $($generics)* Iterator for $name $($generics)* {
+            type Item = $item;
+
+            #[inline]
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next().map(|(_, v)| v)
+            }
+        }
+
+        impl $($generics)* DoubleEndedIterator for $name $($generics)* {
+            #[inline]
+            fn next_back(&mut self) -> Option<Self::Item> {
+                self.0.next_back().map(|(_, v)| v)
+            }
+        }
+
+        impl $($generics)* ExactSizeIterator for $name $($generics)* {
+            #[inline]
+            fn len(&self) -> usize {
+                self.0.len()
+            }
+        }
+
+        impl $($generics)* FusedIterator for $name $($generics)* {}
+    };
+}
+
+/// An iterator over the values of a `Object`.
+pub struct Values<'a>(Iter<'a>);
+impl_value_iter!((Values<'a>): &'a Value);
+
+/// A mutable iterator over the values of a `Object`.
+pub struct ValuesMut<'a>(IterMut<'a>);
+impl_value_iter!((ValuesMut<'a>): &'a mut Value);
+
+impl<'a> IntoIterator for &'a Object {
+    type Item = (&'a str, &'a Value);
+    type IntoIter = Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Object {
+    type Item = (&'a str, &'a mut Value);
+    type IntoIter = IterMut<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<'a, Q: AsRef<str> + ?Sized> std::ops::Index<&'a Q> for Object {
+    type Output = Value;
+
+    #[inline]
+    fn index(&self, index: &'a Q) -> &Self::Output {
+        self.get(&index.as_ref()).unwrap()
+    }
+}
+
+impl<'a, Q: AsRef<str> + ?Sized> std::ops::IndexMut<&'a Q> for Object {
+    #[inline]
+    fn index_mut(&mut self, index: &'a Q) -> &mut Self::Output {
+        self.get_mut(&index.as_ref()).unwrap()
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+impl serde::ser::Serialize for Object {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = tri!(serializer.serialize_map(Some(self.len())));
+        for (k, v) in self {
+            tri!(map.serialize_entry(k, v));
+        }
+        map.end()
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Object {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        // deserialize to value at first
+        let value: Value =
+            deserializer.deserialize_newtype_struct(super::de::TOKEN, super::de::ValueVisitor)?;
+        if value.is_object() {
+            Ok(Object(value))
+        } else {
+            Err(serde::de::Error::invalid_type(
+                serde::de::Unexpected::Other("not a object"),
+                &"object",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::object;
+    use crate::Array;
+    use crate::JsonValueMutTrait;
+    use crate::{from_str, to_string};
+
+    #[test]
+    fn test_object_serde() {
+        let json = r#"{"a": 1, "b": true, "c": null}"#;
+        let obj: Object = from_str(json).unwrap();
+        assert_eq!(obj, object! {"a": 1, "b": true, "c": null});
+        let json = to_string(&obj).unwrap();
+        assert_eq!(json, r#"{"a":1,"b":true,"c":null}"#);
+    }
+
+    #[test]
+    fn test_value_object() {
+        let mut val = crate::from_str::<Value>(r#"{"a": 123, "b": "hello"}"#);
+        let obj = val.as_object_mut().unwrap();
+
+        for i in 0..3 {
+            // push static node
+            let new_node = Value::new_u64(i, std::ptr::null());
+            obj.insert(&"c", new_node);
+            assert_eq!(obj["c"], i);
+
+            // push node with new allocator
+            let mut new_node = Array::default();
+            new_node.push(Value::new_u64(i, std::ptr::null()));
+            obj.insert(&"d", new_node);
+            assert_eq!(obj["d"][0], i);
+
+            // push node with self allocator
+            let mut new_node = Array::new_in(obj.0.shared_clone());
+            new_node.push(Value::new_u64(i, std::ptr::null()));
+            obj.insert(&"e", new_node);
+            assert_eq!(obj["e"][0], i);
+        }
+
+        for (i, v) in obj.iter_mut().enumerate() {
+            *(v.1) = Value::from(&i.to_string());
+        }
+
+        for (i, v) in obj.iter().enumerate() {
+            assert_eq!(v.1, &Value::from(&i.to_string()));
+        }
+    }
+}

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,0 +1,332 @@
+use super::object::Pair;
+use crate::value::node::Value;
+use crate::value::value_trait::{JsonContainerTrait, JsonValueTrait};
+use crate::JsonType;
+use faststr::FastStr;
+impl Eq for Value {}
+
+impl PartialEq for Value {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        if std::ptr::eq(self, other) {
+            return true;
+        }
+
+        if self.get_type() != other.get_type() {
+            return false;
+        }
+
+        match self.get_type() {
+            JsonType::Boolean => self.as_bool() == other.as_bool(),
+            JsonType::Null => other.is_null(),
+            JsonType::Number => self.as_f64() == other.as_f64(),
+            JsonType::String => self.as_str() == other.as_str(),
+            JsonType::Array => {
+                let len = self.len();
+                if len != other.len() {
+                    return false;
+                }
+                let ours = self.children::<Value>();
+                let theirs = other.children::<Value>();
+                ours.iter().zip(theirs).all(|(a, b)| (*a) == b)
+            }
+            JsonType::Object => {
+                let len = self.len();
+                if len != other.len() {
+                    return false;
+                }
+                if len == 0 {
+                    return true;
+                }
+
+                for (k, v) in self.iter::<Pair>() {
+                    let key = k.as_str().unwrap();
+                    let matched = other.get(key).map(|v1| v == v1).unwrap_or(false);
+                    if !matched {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+}
+
+macro_rules! impl_str_eq {
+    ($($eq:ident [$($ty:ty)*])*) => {
+        $($(
+            impl PartialEq<$ty> for Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    let s: &str = other.as_ref();
+                    $eq(self, s)
+                }
+            }
+
+            impl PartialEq<Value> for $ty {
+                #[inline]
+                fn eq(&self, other: &Value) -> bool {
+                    let s: &str = self.as_ref();
+                    $eq(other, s)
+                }
+            }
+
+            impl PartialEq<$ty> for &Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    let s: &str = other.as_ref();
+                    $eq(*self, s)
+                }
+            }
+
+            impl PartialEq<$ty> for &mut Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    let s: &str = other.as_ref();
+                    $eq(*self, s)
+                }
+            }
+        )*)*
+    }
+}
+
+impl_str_eq! {
+    eq_str[str String FastStr]
+}
+
+impl PartialEq<&str> for Value {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        eq_str(self, other)
+    }
+}
+
+impl PartialEq<Value> for &str {
+    #[inline]
+    fn eq(&self, other: &Value) -> bool {
+        eq_str(other, self)
+    }
+}
+
+///////////////////////////////////////////////////////////////////
+// Copied from serde_json
+
+#[inline]
+fn eq_i64(value: &Value, other: i64) -> bool {
+    value.as_i64().map_or(false, |i| i == other)
+}
+
+#[inline]
+fn eq_u64(value: &Value, other: u64) -> bool {
+    value.as_u64().map_or(false, |i| i == other)
+}
+
+#[inline]
+fn eq_f64(value: &Value, other: f64) -> bool {
+    value.as_f64().map_or(false, |i| i == other)
+}
+
+#[inline]
+fn eq_bool(value: &Value, other: bool) -> bool {
+    value.as_bool().map_or(false, |i| i == other)
+}
+
+#[inline]
+fn eq_str(value: &Value, other: &str) -> bool {
+    value.as_str().map_or(false, |i| i == other)
+}
+
+macro_rules! impl_numeric_eq {
+    ($($eq:ident [$($ty:ty)*])*) => {
+        $($(
+            impl PartialEq<$ty> for Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    $eq(self, *other as _)
+                }
+            }
+
+            impl PartialEq<Value> for $ty {
+                #[inline]
+                fn eq(&self, other: &Value) -> bool {
+                    $eq(other, *self as _)
+                }
+            }
+
+            impl PartialEq<$ty> for &Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    $eq(*self, *other as _)
+                }
+            }
+
+            impl PartialEq<$ty> for &mut Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    $eq(*self, *other as _)
+                }
+            }
+        )*)*
+    }
+}
+
+impl_numeric_eq! {
+    eq_i64[i8 i16 i32 i64 isize]
+    eq_u64[u8 u16 u32 u64 usize]
+    eq_f64[f32 f64]
+    eq_bool[bool]
+}
+
+//////////////////////////////////////////////////////////////////////////////
+
+macro_rules! impl_slice_eq {
+    ([$($vars:tt)*], $rhs:ty $(where $ty:ty: $bound:ident)?) => {
+        impl<U, $($vars)*> PartialEq<$rhs> for Array
+        where
+            Value: PartialEq<U>,
+            $($ty: $bound)?
+        {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                let len = self.len();
+                if len != other.len() {
+                    return false;
+                }
+                let slf = self.as_ref();
+                let other: &[U] = other.as_ref();
+                slf.iter().zip(other).all(|(a, b)| *a == *b )
+            }
+        }
+
+        impl<U, $($vars)*> PartialEq<$rhs> for Value
+        where
+            Value: PartialEq<U>,
+            $($ty: $bound)?
+        {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                self.as_array().map(|arr| arr == other).unwrap_or(false)
+            }
+        }
+
+
+        impl<U, $($vars)*> PartialEq<Array> for $rhs
+        where
+            Value: PartialEq<U>,
+            $($ty: $bound)?
+        {
+            #[inline]
+            fn eq(&self, other: &Array) -> bool {
+                other == self
+            }
+        }
+
+        impl<U, $($vars)*> PartialEq<Value> for $rhs
+        where
+            Value: PartialEq<U>,
+            $($ty: $bound)?
+        {
+            #[inline]
+            fn eq(&self, other: &Value) -> bool {
+                other == self
+            }
+        }
+    }
+}
+
+impl_slice_eq!([], &[U]);
+impl_slice_eq!([], &mut [U]);
+impl_slice_eq!([], [U]);
+impl_slice_eq!([const N: usize], &[U; N]);
+impl_slice_eq!([const N: usize], [U; N]);
+impl_slice_eq!([], Vec<U>);
+
+//////////////////////////////////////////////////////////////////////////////
+
+use super::array::Array;
+use super::object::Object;
+
+// TODO: compare value with object/array.
+
+macro_rules! impl_container_eq {
+    ($($ty:ty)*) => {
+        $(
+            impl PartialEq<$ty> for Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    self == &other.0
+                }
+            }
+
+            impl PartialEq<Value> for $ty {
+                #[inline]
+                fn eq(&self, other: &Value) -> bool {
+                    other == &self.0
+                }
+            }
+
+            impl  PartialEq<$ty> for &Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    *self == &other.0
+                }
+            }
+
+            impl  PartialEq<$ty> for &mut Value {
+                #[inline]
+                fn eq(&self, other: &$ty) -> bool {
+                    *self == &other.0
+                }
+            }
+
+            impl PartialEq<Value> for &$ty {
+                #[inline]
+                fn eq(&self, other: &Value) -> bool {
+                    other == &self.0
+                }
+            }
+
+            impl PartialEq<Value> for &mut $ty {
+                #[inline]
+                fn eq(&self, other: &Value) -> bool {
+                    other == &self.0
+                }
+            }
+
+        )*
+    }
+}
+
+impl_container_eq!(Array Object);
+
+#[cfg(test)]
+mod test {
+    use crate::{array, json};
+    use faststr::FastStr;
+    #[test]
+    fn test_slice_eq() {
+        assert_eq!(json!([1, 2, 3]), &[1, 2, 3]);
+        assert_eq!(array![1, 2, 3], &[1, 2, 3]);
+        assert_eq!(json!([1, 2, 3]), array![1, 2, 3].as_slice());
+
+        assert_eq!(json!([1, 2, 3]), vec![1, 2, 3]);
+        assert_eq!(vec![1, 2, 3], array![1, 2, 3]);
+        assert_eq!(array![1, 2, 3], &[1, 2, 3][..]);
+        assert_eq!(json!([1, 2, 3]), array![1, 2, 3].as_slice());
+    }
+
+    #[test]
+    fn test_str_eq() {
+        assert_eq!(json!("123"), FastStr::new("123"));
+        assert_eq!(json!("123"), "123");
+    }
+
+    #[test]
+    fn test_container_eq() {
+        assert_eq!(json!([1, 2, 3]), array![1, 2, 3]);
+        assert_eq!(array![1, 2, 3], json!([1, 2, 3]));
+        assert_eq!(json!({"a": 1, "b": 2}), json!({"b": 2, "a": 1}));
+        assert_eq!(json!({"a": 1, "b": 2}), object! {"a": 1, "b": 2});
+        assert_eq!(object! {"a": 1, "b": 2}, json!({"a": 1, "b": 2}));
+    }
+}

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,0 +1,813 @@
+use super::shared::Shared;
+use crate::error::{Error, ErrorCode, Result};
+use crate::util::arc::Arc;
+use crate::value::node::Value;
+use crate::JsonValueTrait;
+use core::fmt::Display;
+use serde::ser::{Impossible, Serialize};
+use std::ptr::NonNull;
+
+/// Convert a `T` into `sonic_rs::Value` which can represent any valid JSON data.
+///
+/// # Example
+///
+/// ```
+/// use serde::Serialize;
+/// use sonic_rs::{json, to_value, Value};
+///
+/// #[derive(Serialize, Debug)]
+/// struct User {
+///     string: String,
+///     number: i32,
+///     array: Vec<String>,
+/// }
+///
+///  let user = User{
+///      string: "hello".into(),
+///      number: 123,
+///      array: vec!["a".into(), "b".into(), "c".into()],
+///  };
+///  let got: Value = sonic_rs::to_value(&user).unwrap();
+///  let expect = json!({
+///      "string": "hello",
+///      "number": 123,
+///      "array": ["a", "b", "c"],
+///  });
+///  assert_eq!(got, expect);
+/// ```
+///
+/// # Errors
+///
+/// This conversion can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// use sonic_rs::to_value;
+///
+///  // The keys in this map are vectors, not strings.
+///  let mut map = BTreeMap::new();
+///  map.insert(vec![32, 64], "x86");
+///  let err = to_value(&map).unwrap_err().to_string();
+///  assert!(err.contains("key must be string"));
+///
+/// ```
+pub fn to_value<T>(value: &T) -> Result<Value>
+where
+    T: ?Sized + Serialize,
+{
+    let shared = Arc::new(Shared::new());
+    let mut value = to_value_in(
+        unsafe { NonNull::new_unchecked(shared.data_ptr() as *mut _) },
+        value,
+    )?;
+    if value.is_number() {
+        value.mark_shared(std::ptr::null());
+    } else {
+        value.mark_root();
+        std::mem::forget(shared);
+    }
+    Ok(value)
+}
+
+// Not export this because it is mainly used in `json!`.
+pub(crate) struct Serializer(NonNull<Shared>);
+
+impl Serializer {
+    #[inline]
+    fn new_in(share: NonNull<Shared>) -> Self {
+        Self(share)
+    }
+
+    #[inline]
+    fn shared(&self) -> NonNull<Shared> {
+        self.0
+    }
+
+    #[inline]
+    fn shared_ptr(&self) -> *const Shared {
+        self.0.as_ptr()
+    }
+
+    #[inline]
+    fn shared_ref(&self) -> &Shared {
+        unsafe { self.0.as_ref() }
+    }
+}
+
+use crate::serde::tri;
+use std::string::ToString;
+
+impl serde::Serializer for Serializer {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = SerializeVec;
+    type SerializeTuple = SerializeVec;
+    type SerializeTupleStruct = SerializeVec;
+    type SerializeTupleVariant = SerializeTupleVariant;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = SerializeStructVariant;
+
+    #[inline]
+    fn serialize_unit(self) -> Result<Value> {
+        Ok(Value::new_null(self.shared_ptr()))
+    }
+
+    #[inline]
+    fn serialize_bool(self, value: bool) -> Result<Value> {
+        Ok(Value::new_bool(value, self.shared_ptr()))
+    }
+
+    #[inline]
+    fn serialize_i8(self, value: i8) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    #[inline]
+    fn serialize_i16(self, value: i16) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    #[inline]
+    fn serialize_i32(self, value: i32) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Value> {
+        Ok(Value::new_i64(value, self.shared_ptr()))
+    }
+
+    fn serialize_i128(self, value: i128) -> Result<Value> {
+        if let Ok(value) = u64::try_from(value) {
+            Ok(Value::new_u64(value, self.shared_ptr()))
+        } else if let Ok(value) = i64::try_from(value) {
+            Ok(Value::new_i64(value, self.shared_ptr()))
+        } else {
+            // FIXME: print i128 in error message
+            Err(Error::syntax(ErrorCode::NumberOutOfRange, b"", 0))
+        }
+    }
+
+    #[inline]
+    fn serialize_u8(self, value: u8) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    #[inline]
+    fn serialize_u16(self, value: u16) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    #[inline]
+    fn serialize_u32(self, value: u32) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    #[inline]
+    fn serialize_u64(self, value: u64) -> Result<Value> {
+        Ok(Value::new_u64(value, self.shared_ptr()))
+    }
+
+    fn serialize_u128(self, value: u128) -> Result<Value> {
+        if let Ok(value) = u64::try_from(value) {
+            Ok(Value::new_u64(value, self.shared_ptr()))
+        } else {
+            Err(Error::syntax(ErrorCode::NumberOutOfRange, b"", 0))
+        }
+    }
+
+    #[inline]
+    fn serialize_f32(self, value: f32) -> Result<Value> {
+        if value.is_finite() {
+            Ok(unsafe { Value::new_f64_unchecked(value as f64, self.shared_ptr()) })
+        } else {
+            Err(Error::syntax(ErrorCode::FloatMustBeFinite, b"", 0))
+        }
+    }
+
+    #[inline]
+    fn serialize_f64(self, value: f64) -> Result<Value> {
+        if value.is_finite() {
+            Ok(unsafe { Value::new_f64_unchecked(value, self.shared_ptr()) })
+        } else {
+            Err(Error::syntax(ErrorCode::FloatMustBeFinite, b"", 0))
+        }
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Value> {
+        Ok(Value::copy_str(&value.to_string(), self.shared_ref()))
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<Value> {
+        Ok(Value::copy_str(value, self.shared_ref()))
+    }
+
+    // parse bytes as a array with u64
+    fn serialize_bytes(self, value: &[u8]) -> Result<Value> {
+        let mut array = Value::new_array(self.shared_ptr(), value.len());
+        for b in value.iter() {
+            array.append_value(Value::new_u64((*b) as u64, self.shared_ptr()));
+        }
+        Ok(array)
+    }
+
+    #[inline]
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Value> {
+        self.serialize_str(variant)
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        let mut object = Value::new_object(self.shared_ptr(), 1);
+        let pair = (
+            Value::new_str(variant, self.shared_ptr()),
+            tri!(to_value_in(self.shared(), value)),
+        );
+        object.append_pair(pair);
+        Ok(object)
+    }
+
+    #[inline]
+    fn serialize_none(self) -> Result<Value> {
+        self.serialize_unit()
+    }
+
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    #[inline]
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(SerializeVec {
+            shared: self.shared(),
+            vec: Value::new_array(self.shared_ptr(), len.unwrap_or_default()),
+        })
+    }
+
+    #[inline]
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+        self.serialize_seq(Some(len))
+    }
+
+    #[inline]
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        self.serialize_seq(Some(len))
+    }
+
+    #[inline]
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Ok(SerializeTupleVariant {
+            shared: self.shared(),
+            static_name: Value::new_str(variant, self.shared_ptr()),
+            vec: Value::new_array(self.shared_ptr(), len),
+        })
+    }
+
+    #[inline]
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
+        Ok(SerializeMap {
+            map: MapInner::Object {
+                object: Value::new_object(self.shared_ptr(), len.unwrap_or_default()),
+                next_key: None,
+            },
+            shared: self.shared(),
+        })
+    }
+
+    #[inline]
+    fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
+        match name {
+            crate::serde::number::TOKEN => Ok(SerializeMap {
+                map: MapInner::RawNumber { out_value: None },
+                shared: self.shared(),
+            }),
+            crate::serde::raw::TOKEN => Ok(SerializeMap {
+                map: MapInner::RawValue { out_value: None },
+                shared: self.shared(),
+            }),
+            _ => self.serialize_map(Some(len)),
+        }
+    }
+
+    #[inline]
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Ok(SerializeStructVariant {
+            shared: self.shared(),
+            static_name: Value::new_str(variant, self.shared_ptr()),
+            object: Value::new_object(self.shared_ptr(), len),
+        })
+    }
+
+    #[inline]
+    fn collect_str<T>(self, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Display,
+    {
+        self.serialize_str(&value.to_string())
+    }
+}
+
+/// Serializing Rust seq into `Value`.
+pub(crate) struct SerializeVec {
+    shared: NonNull<Shared>,
+    vec: Value,
+}
+
+/// Serializing Rust tuple variant into `Value`.
+pub(crate) struct SerializeTupleVariant {
+    shared: NonNull<Shared>,
+    static_name: Value,
+    vec: Value,
+}
+
+/// Serializing Rust into `Value`. We has special handling for `Number`, `RawNumber` and `RawValue`.
+pub(crate) struct SerializeMap {
+    map: MapInner,
+    shared: NonNull<Shared>,
+}
+
+enum MapInner {
+    Object {
+        object: Value,
+        next_key: Option<Value>, // object key is value
+    },
+    RawNumber {
+        out_value: Option<Value>,
+    },
+    RawValue {
+        out_value: Option<Value>,
+    },
+}
+
+/// Serializing Rust struct variant into `Value`.
+pub(crate) struct SerializeStructVariant {
+    static_name: Value,
+    object: Value,
+    shared: NonNull<Shared>,
+}
+
+impl serde::ser::SerializeSeq for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.vec.append_value(tri!(to_value_in(self.shared, value)));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        Ok(self.vec)
+    }
+}
+
+impl serde::ser::SerializeTuple for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl serde::ser::SerializeTupleStruct for SerializeVec {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        serde::ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value> {
+        serde::ser::SerializeSeq::end(self)
+    }
+}
+
+impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.vec.append_value(tri!(to_value_in(self.shared, value)));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        let mut object = Value::new_object(self.shared.as_ptr(), 1);
+        object.append_pair((self.static_name, self.vec));
+        Ok(object)
+    }
+}
+
+impl serde::ser::SerializeMap for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match &mut self.map {
+            MapInner::Object { next_key, .. } => {
+                *next_key = Some(tri!(key.serialize(MapKeySerializer(self.shared))));
+                Ok(())
+            }
+            MapInner::RawNumber { .. } => unreachable!(),
+            MapInner::RawValue { .. } => unreachable!(),
+        }
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match &mut self.map {
+            MapInner::Object { object, next_key } => {
+                let key = next_key.take();
+                // Panic because this indicates a bug in the program rather than an
+                // expected failure.
+                let key = key.expect("serialize_value called before serialize_key");
+                object.append_pair((key, tri!(to_value_in(self.shared, value))));
+                Ok(())
+            }
+            MapInner::RawNumber { .. } => unreachable!(),
+            MapInner::RawValue { .. } => unreachable!(),
+        }
+    }
+
+    fn end(self) -> Result<Value> {
+        match self.map {
+            MapInner::Object { object, .. } => Ok(object),
+            MapInner::RawNumber { .. } => unreachable!(),
+            MapInner::RawValue { .. } => unreachable!(),
+        }
+    }
+}
+
+// Serialize the map key into a Value.
+struct MapKeySerializer(NonNull<Shared>);
+
+impl MapKeySerializer {
+    fn shared_ptr(&self) -> *const Shared {
+        self.0.as_ptr()
+    }
+}
+
+fn key_must_be_a_string() -> Error {
+    Error::syntax(ErrorCode::ValueKeyMustBeString, b"", 0)
+}
+
+fn float_key_must_be_finite() -> Error {
+    Error::syntax(ErrorCode::FloatMustBeFinite, b"", 0)
+}
+
+impl serde::Serializer for MapKeySerializer {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<Value, Error>;
+    type SerializeTuple = Impossible<Value, Error>;
+    type SerializeTupleStruct = Impossible<Value, Error>;
+    type SerializeTupleVariant = Impossible<Value, Error>;
+    type SerializeMap = Impossible<Value, Error>;
+    type SerializeStruct = Impossible<Value, Error>;
+    type SerializeStructVariant = Impossible<Value, Error>;
+
+    #[inline]
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Value> {
+        Ok(Value::new_str(variant, self.shared_ptr()))
+    }
+
+    #[inline]
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_bool(self, value: bool) -> Result<Value> {
+        if value {
+            Ok(Value::new_str("true", self.shared_ptr()))
+        } else {
+            Ok(Value::new_str("false", self.shared_ptr()))
+        }
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Value> {
+        self.serialize_i64(value as i64)
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Value> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Value> {
+        self.serialize_u64(value as u64)
+    }
+
+    // FIXME: optimize the copy overhead
+    fn serialize_u64(self, value: u64) -> Result<Value> {
+        self.serialize_str(itoa::Buffer::new().format(value))
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Value> {
+        if value.is_finite() {
+            self.serialize_str(ryu::Buffer::new().format_finite(value))
+        } else {
+            Err(float_key_must_be_finite())
+        }
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Value> {
+        if value.is_finite() {
+            self.serialize_str(ryu::Buffer::new().format_finite(value))
+        } else {
+            Err(float_key_must_be_finite())
+        }
+    }
+
+    #[inline]
+    fn serialize_char(self, value: char) -> Result<Value> {
+        self.serialize_str(&value.to_string())
+    }
+
+    #[inline]
+    fn serialize_str(self, value: &str) -> Result<Value> {
+        let shared = unsafe { self.0.as_ref() };
+        Ok(Value::copy_str(value, shared))
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Value> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit(self) -> Result<Value> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_none(self) -> Result<Value> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_some<T>(self, _value: &T) -> Result<Value>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Err(key_must_be_a_string())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(key_must_be_a_string())
+    }
+
+    fn collect_str<T>(self, value: &T) -> Result<Value>
+    where
+        T: ?Sized + Display,
+    {
+        self.serialize_str(&value.to_string())
+    }
+}
+
+impl serde::ser::SerializeStruct for SerializeMap {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        match &mut self.map {
+            MapInner::Object { .. } => serde::ser::SerializeMap::serialize_entry(self, key, value),
+            MapInner::RawNumber { out_value: _ } => {
+                todo!()
+            }
+            MapInner::RawValue { out_value: _ } => {
+                todo!()
+            }
+        }
+    }
+
+    fn end(self) -> Result<Value> {
+        match self.map {
+            MapInner::Object { .. } => serde::ser::SerializeMap::end(self),
+            MapInner::RawNumber { out_value, .. } => {
+                Ok(out_value.expect("number value was not emitted"))
+            }
+            MapInner::RawValue { out_value, .. } => {
+                Ok(out_value.expect("raw value was not emitted"))
+            }
+        }
+    }
+}
+
+impl serde::ser::SerializeStructVariant for SerializeStructVariant {
+    type Ok = Value;
+    type Error = Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.object.append_pair((
+            Value::new_str(key, self.shared.as_ptr()),
+            tri!(to_value_in(self.shared, value)),
+        ));
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value> {
+        let mut object = Value::new_object(self.shared.as_ptr(), 1);
+        object.append_pair((self.static_name, self.object));
+        Ok(object)
+    }
+}
+
+#[doc(hidden)]
+#[inline]
+pub fn to_value_in<T>(shared: NonNull<Shared>, value: &T) -> Result<Value>
+where
+    T: ?Sized + Serialize,
+{
+    let serializer = Serializer::new_in(shared);
+    value.serialize(serializer)
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test_to_value() {
+        use crate::json;
+        use crate::to_value;
+        use crate::Value;
+        #[derive(Debug, serde::Serialize)]
+        struct User {
+            string: String,
+            number: i32,
+            array: Vec<String>,
+        }
+
+        let user = User {
+            string: "hello".into(),
+            number: 123,
+            array: vec!["a".into(), "b".into(), "c".into()],
+        };
+        let got: Value = to_value(&user).unwrap();
+        let expect = json!({
+            "string": "hello",
+            "number": 123,
+            "array": ["a", "b", "c"],
+        });
+        assert_eq!(got, expect);
+
+        let got: Value = to_value("hello").unwrap();
+        assert_eq!(got, "hello");
+
+        let got: Value = to_value(&123).unwrap();
+        assert_eq!(got, 123);
+    }
+}

--- a/src/value/shared.rs
+++ b/src/value/shared.rs
@@ -1,0 +1,72 @@
+use super::alloctor::SyncBump;
+use crate::util::{arc::Arc, taggedptr::TaggedPtr};
+use std::{
+    fmt::{Debug, Formatter},
+    mem::ManuallyDrop,
+    sync::atomic::AtomicBool,
+};
+
+// Represent a shared allocator.
+#[derive(Debug)]
+#[repr(align(16))]
+#[doc(hidden)]
+pub struct Shared {
+    pub(crate) alloc: SyncBump,
+    // Whether there are multiple allocator in the `Value` tree.
+    // the flag is conservative to make sure no memory leaks, more details see `Drop` comments.
+    pub(crate) combined: AtomicBool,
+}
+
+impl Debug for Arc<Shared> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Shared")
+            .field("refcnt", &self.refcnt())
+            .field("combined", &self.combined)
+            .field("allocator address", &self.alloc.0.data_ptr())
+            .finish()
+    }
+}
+
+impl Default for Shared {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Shared {
+    pub(crate) fn new() -> Self {
+        Self {
+            alloc: SyncBump::new(),
+            combined: AtomicBool::new(false),
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn new_ptr() -> *const Shared {
+        ManuallyDrop::new(Arc::new(Shared::new())).data_ptr()
+    }
+
+    /// there are no way to convert the `combined` from true to false
+    /// so we can use relaxed ordering here.
+    /// And The origin refcnt of Shared prevents other threads from erroneously deleting
+    // the shared allocator.
+    pub(crate) fn is_combined(&self) -> bool {
+        self.combined.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// The origin refcnt of Shared prevents other threads from erroneously deleting
+    // the shared allocator.
+    pub(crate) fn set_combined(&self) {
+        self.combined
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// TaggedPtr is not arc
+impl Clone for TaggedPtr<Shared> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl Copy for TaggedPtr<Shared> {}

--- a/src/value/tryfrom.rs
+++ b/src/value/tryfrom.rs
@@ -1,4 +1,5 @@
 use super::Value;
+use crate::LazyValue;
 use crate::Number;
 
 impl TryFrom<f32> for Value {
@@ -49,5 +50,27 @@ impl TryFrom<f64> for Value {
     #[inline]
     fn try_from(value: f64) -> Result<Self, Self::Error> {
         Number::try_from(value).map(Into::into)
+    }
+}
+
+/// Try parse a `LazyValue` into a `Value`.  `LazyValue` is always a valid JSON, at least it is followed the JSON syntax.
+///
+/// However, in some cases, the parse will failed and return errors, such as the float number in JSON is inifity.
+///
+/// # Examples
+/// ```
+/// use sonic_rs::{Value, Result};
+/// use sonic_rs::JsonValueTrait;
+/// use sonic_rs::LazyValue;
+///
+/// let lazy = sonic_rs::get(r#"{"a": 111e9999999, "b": 2}"#, &["a"]).unwrap();
+/// let x1: Result<Value> = lazy.try_into();
+///
+/// assert!(x1.unwrap_err().to_string().contains("Number is bigger than the maximum value"));
+/// ```
+impl<'de> TryFrom<LazyValue<'de>> for Value {
+    type Error = crate::Error;
+    fn try_from(value: LazyValue<'de>) -> Result<Self, Self::Error> {
+        crate::from_str(value.as_raw_str())
     }
 }

--- a/src/value/tryfrom.rs
+++ b/src/value/tryfrom.rs
@@ -66,7 +66,7 @@ impl TryFrom<f64> for Value {
 /// let lazy = sonic_rs::get(r#"{"a": 111e9999999, "b": 2}"#, &["a"]).unwrap();
 /// let x1: Result<Value> = lazy.try_into();
 ///
-/// assert!(x1.unwrap_err().to_string().contains("Number is bigger than the maximum value"));
+/// assert!(x1.unwrap_err().to_string().contains("Float number must be finite"));
 /// ```
 impl<'de> TryFrom<LazyValue<'de>> for Value {
     type Error = crate::Error;

--- a/src/value/tryfrom.rs
+++ b/src/value/tryfrom.rs
@@ -1,0 +1,53 @@
+use super::Value;
+use crate::Number;
+
+impl TryFrom<f32> for Value {
+    type Error = crate::Error;
+
+    /// Try convert a f32 to `Value`. If the float is NaN or infinity, return a error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use sonic_rs::JsonValueTrait;
+    ///
+    /// let f1: f32 = 2.333;
+    /// let x1: Value = f1.try_into().unwrap();
+    /// assert_eq!(x1, f1);
+    ///
+    /// let x2: Value =  f32::INFINITY.try_into().unwrap_or_default();
+    /// let x3: Value =  f32::NAN.try_into().unwrap_or_default();
+    ///
+    /// assert!(x2.is_null() && x3.is_null());
+    /// ```
+    #[inline]
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        Number::try_from(value).map(Into::into)
+    }
+}
+
+impl TryFrom<f64> for Value {
+    /// Try convert a f64 to `Value`. If the float is NaN or infinity, return a error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::Value;
+    /// use sonic_rs::JsonValueTrait;
+    ///
+    /// let f1: f64 = 2.333;
+    /// let x1: Value = f1.try_into().unwrap();
+    /// assert_eq!(x1, 2.333);
+    ///
+    /// let x2: Value =  f64::INFINITY.try_into().unwrap_or_default();
+    /// let x3: Value =  f64::NAN.try_into().unwrap_or_default();
+    ///
+    /// assert!(x2.is_null() && x3.is_null());
+    /// ```
+    type Error = crate::Error;
+    #[inline]
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Number::try_from(value).map(Into::into)
+    }
+}

--- a/src/value/value_trait.rs
+++ b/src/value/value_trait.rs
@@ -43,7 +43,27 @@ pub trait JsonValueTrait {
     where
         Self: 'v;
 
-    /// get the type of the `JsonValue`.
+    /// Gets the type of the `JsonValue`. Returns `JsonType::Null` as default if `self` is `Option::None` or `Result::Err(_)`.
+    ///
+    /// # Examples
+    /// ```
+    /// use sonic_rs::value::JsonType;
+    /// use sonic_rs::value::JsonValueTrait;
+    /// use sonic_rs::value::Value;
+    /// use sonic_rs::Result;
+    ///
+    /// let json = sonic_rs:from_str(r#"{"a": 1, "b": true}"#).unwrap();
+    ///
+    /// assert_eq!(json.get_type(), JsonType::Object);
+    ///
+    /// let v: Option<&Value> = json.get("c");
+    /// assert!(v.is_none());
+    /// assert_eq!(v.get_type(), JsonType::Null);
+    ///
+    /// let v: Result<Value> =  sonic_rs::from_str(r#"{"invalid json"#);
+    /// assert!(v.is_err());
+    /// assert_eq!(v.get_type(), JsonType::Null);
+    /// ```
     fn get_type(&self) -> JsonType;
 
     /// Returns true if the `JsonValue` is a `bool`.
@@ -140,7 +160,7 @@ pub trait JsonValueTrait {
     fn as_bool(&self) -> Option<bool>;
 
     /// Returns the value from index if the `JsonValue` is an `array` or `object`
-    /// The index may be usize or &str. The `usize` is for array, the `&str` is for object. If not found, return `None`.
+    /// The index may be usize or &str. The `usize` is for array, the `&str` is for object. Returns None otherwise.
     ///
     /// # Examples
     /// ```
@@ -155,7 +175,7 @@ pub trait JsonValueTrait {
     /// ```
     fn get<I: Index>(&self, index: I) -> Option<Self::ValueType<'_>>;
 
-    /// Returns the value from pointer path if the `JsonValue` is an `array` or `object`
+    /// Returns the value from pointer path if the `JsonValue` is an array or object. Returns None otherwise.
     fn pointer(&self, path: &JsonPointer) -> Option<Self::ValueType<'_>>;
 }
 

--- a/src/value/value_trait.rs
+++ b/src/value/value_trait.rs
@@ -52,7 +52,7 @@ pub trait JsonValueTrait {
     /// use sonic_rs::value::Value;
     /// use sonic_rs::Result;
     ///
-    /// let json = sonic_rs:from_str(r#"{"a": 1, "b": true}"#).unwrap();
+    /// let json: Value = sonic_rs::from_str(r#"{"a": 1, "b": true}"#).unwrap();
     ///
     /// assert_eq!(json.get_type(), JsonType::Object);
     ///
@@ -168,7 +168,7 @@ pub trait JsonValueTrait {
     /// use sonic_rs::value::JsonValueTrait;
     /// use sonic_rs::value::Value;
     ///
-    /// let json = Value::from_str(r#"{"a": 1, "b": true}"#).unwrap();
+    /// let json: Value = sonic_rs::from_str(r#"{"a": 1, "b": true}"#).unwrap();
     ///
     /// assert!(json.get("a").is_number());
     /// assert!(json.get("unknown").is_none());

--- a/src/value/value_trait.rs
+++ b/src/value/value_trait.rs
@@ -1,12 +1,11 @@
-use super::index::Index;
-use crate::{JsonNumberTrait, JsonPointer, Number};
+use crate::index::Index;
+use crate::{JsonNumberTrait, Number};
 
 /// JsonType is an enum that represents the type of a JSON value.
 ///
 /// # Examples
 /// ```
-///  use sonic_rs::JsonType;
-///  use sonic_rs::Value;
+///  use sonic_rs::{Value, JsonValueTrait, JsonType};
 ///
 ///  let json: Value = sonic_rs::from_str(r#"{"a": 1, "b": true}"#).unwrap();
 ///
@@ -176,7 +175,9 @@ pub trait JsonValueTrait {
     fn get<I: Index>(&self, index: I) -> Option<Self::ValueType<'_>>;
 
     /// Returns the value from pointer path if the `JsonValue` is an array or object. Returns None otherwise.
-    fn pointer(&self, path: &JsonPointer) -> Option<Self::ValueType<'_>>;
+    fn pointer<P: IntoIterator>(&self, path: P) -> Option<Self::ValueType<'_>>
+    where
+        P::Item: Index;
 }
 
 /// A trait for all JSON object or array values. Used by `Value`.
@@ -204,7 +205,9 @@ pub trait JsonValueMutTrait {
     fn as_array_mut(&mut self) -> Option<&mut Self::ArrayType>;
 
     /// Returns the value from pointer path if the `JsonValue` is an `array` or `object`
-    fn pointer_mut(&mut self, path: &JsonPointer) -> Option<&mut Self::ValueType>;
+    fn pointer_mut<P: IntoIterator>(&mut self, path: P) -> Option<&mut Self::ValueType>
+    where
+        P::Item: Index;
 
     /// Returns the value from index if the `JsonValue` is an `array` or `object`
     /// The index may be usize or &str. The `usize` is for array, the `&str` is for object.
@@ -247,7 +250,10 @@ impl<V: JsonValueTrait> JsonValueTrait for Option<V> {
         self.as_ref().and_then(|v| v.get(index))
     }
 
-    fn pointer(&self, path: &JsonPointer) -> Option<Self::ValueType<'_>> {
+    fn pointer<P: IntoIterator>(&self, path: P) -> Option<Self::ValueType<'_>>
+    where
+        P::Item: Index,
+    {
         self.as_ref().and_then(|v| v.pointer(path))
     }
 }
@@ -277,7 +283,10 @@ impl<V: JsonValueMutTrait> JsonValueMutTrait for Option<V> {
         self.as_mut().and_then(|v| v.as_object_mut())
     }
 
-    fn pointer_mut(&mut self, path: &JsonPointer) -> Option<&mut Self::ValueType> {
+    fn pointer_mut<P: IntoIterator>(&mut self, path: P) -> Option<&mut Self::ValueType>
+    where
+        P::Item: Index,
+    {
         self.as_mut().and_then(|v| v.pointer_mut(path))
     }
 
@@ -322,7 +331,10 @@ impl<V: JsonValueTrait, E> JsonValueTrait for Result<V, E> {
         self.as_ref().ok().and_then(|v| v.get(index))
     }
 
-    fn pointer(&self, path: &JsonPointer) -> Option<Self::ValueType<'_>> {
+    fn pointer<P: IntoIterator>(&self, path: P) -> Option<Self::ValueType<'_>>
+    where
+        P::Item: Index,
+    {
         self.as_ref().ok().and_then(|v| v.pointer(path))
     }
 }
@@ -352,7 +364,10 @@ impl<V: JsonValueMutTrait, E> JsonValueMutTrait for Result<V, E> {
         self.as_mut().ok().and_then(|v| v.as_object_mut())
     }
 
-    fn pointer_mut(&mut self, path: &JsonPointer) -> Option<&mut Self::ValueType> {
+    fn pointer_mut<P: IntoIterator>(&mut self, path: P) -> Option<&mut Self::ValueType>
+    where
+        P::Item: Index,
+    {
         self.as_mut().ok().and_then(|v| v.pointer_mut(path))
     }
 
@@ -396,7 +411,10 @@ impl<V: JsonValueTrait> JsonValueTrait for &V {
         (*self).get(index)
     }
 
-    fn pointer(&self, path: &JsonPointer) -> Option<Self::ValueType<'_>> {
+    fn pointer<P: IntoIterator>(&self, path: P) -> Option<Self::ValueType<'_>>
+    where
+        P::Item: Index,
+    {
         (*self).pointer(path)
     }
 }
@@ -431,7 +449,10 @@ impl<V: JsonValueMutTrait> JsonValueMutTrait for &mut V {
         (**self).get_mut(index)
     }
 
-    fn pointer_mut(&mut self, path: &JsonPointer) -> Option<&mut Self::ValueType> {
-        (*self).pointer_mut(path)
+    fn pointer_mut<P: IntoIterator>(&mut self, path: P) -> Option<&mut Self::ValueType>
+    where
+        P::Item: Index,
+    {
+        (**self).pointer_mut(path)
     }
 }


### PR DESCRIPTION
To fix #34 


Tasks:

- [x] support parse owned dom in Rust struct

- [x] use thread-local preallocated buffer

- [x] add more apis as serde_json: such as from and from_iter and so on.

Design:
1. use memory poll allocator and smallest node layout
2. shared parts support sync, such as allocator
3. no explicit allocator args

