### PR TITLE
fix: make lazyvalue sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1.0"
 arrayref = "0.3"
 packed_simd = { version = "0.3", package = "packed_simd" }
 
-serde = { version = "1.0", default-features = false }
+serde = { version = "1.0", features = ["rc", "derive"] }
 itoa = "1.0"
 ryu = "1.0"
 faststr = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use core::{
     result,
 };
 use std::{
+    borrow::Cow,
     error,
     str::FromStr,
     string::{String, ToString},
@@ -196,7 +197,7 @@ struct ErrorImpl {
 #[derive(ErrorTrait, Debug)]
 pub(crate) enum ErrorCode {
     #[error("{0}")]
-    Message(Box<str>),
+    Message(Cow<'static, str>),
 
     #[error("io error while serializing or deserializing")]
     Io(std::io::Error),
@@ -435,7 +436,7 @@ pub fn make_error(mut msg: String) -> Error {
     let (line, column) = parse_line_col(&mut msg).unwrap_or((0, 0));
     Error {
         err: Box::new(ErrorImpl {
-            code: ErrorCode::Message(msg.into_boxed_str()),
+            code: ErrorCode::Message(msg.into()),
             line,
             column,
             descript: None,

--- a/src/lazyvalue/de.rs
+++ b/src/lazyvalue/de.rs
@@ -26,7 +26,8 @@ impl<'de: 'a, 'a> Deserialize<'de> for LazyValue<'a> {
             where
                 E: de::Error,
             {
-                Ok(LazyValue::new(FastStr::new(v).into()))
+                // parse the escaped string
+                LazyValue::new(FastStr::new(v).into(), true).map_err(de::Error::custom)
             }
 
             // borrowed from origin json
@@ -34,7 +35,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for LazyValue<'a> {
             where
                 E: de::Error,
             {
-                Ok(LazyValue::new(v.into()))
+                LazyValue::new(FastStr::new(v).into(), false).map_err(de::Error::custom)
             }
         }
 
@@ -64,7 +65,8 @@ impl<'de> Deserialize<'de> for OwnedLazyValue {
             where
                 E: de::Error,
             {
-                Ok(OwnedLazyValue::new(FastStr::new(v).into()))
+                // parse the escaped string
+                OwnedLazyValue::new(FastStr::new(v).into(), true).map_err(de::Error::custom)
             }
 
             // borrowed from origin json
@@ -72,7 +74,7 @@ impl<'de> Deserialize<'de> for OwnedLazyValue {
             where
                 E: de::Error,
             {
-                Ok(OwnedLazyValue::new(v.into()))
+                OwnedLazyValue::new(FastStr::new(v).into(), false).map_err(de::Error::custom)
             }
         }
 

--- a/src/lazyvalue/iterator.rs
+++ b/src/lazyvalue/iterator.rs
@@ -113,9 +113,9 @@ impl<'de> ObjectInner<'de> {
         let parser = unsafe { self.parser.as_mut().unwrap_unchecked() };
         match parser.parse_entry_lazy(&mut self.strbuf, &mut self.first, check) {
             Ok(ret) => {
-                if let Some((key, val)) = ret {
+                if let Some((key, val, has_escaped)) = ret {
                     let val = self.json.slice_ref(val);
-                    Some(Ok((key, LazyValue::new(val))))
+                    Some(LazyValue::new(val, has_escaped).map(|v| (key, v)))
                 } else {
                     self.ending = true;
                     None
@@ -155,9 +155,9 @@ impl<'de> ArrayInner<'de> {
         let parser = unsafe { self.parser.as_mut().unwrap_unchecked() };
         match parser.parse_array_elem_lazy(&mut self.first, check) {
             Ok(ret) => {
-                if let Some(ret) = ret {
+                if let Some((ret, has_escaped)) = ret {
                     let val = self.json.slice_ref(ret);
-                    Some(Ok(LazyValue::new(val)))
+                    Some(LazyValue::new(val, has_escaped))
                 } else {
                     self.ending = true;
                     None

--- a/src/lazyvalue/owned.rs
+++ b/src/lazyvalue/owned.rs
@@ -61,7 +61,7 @@ use crate::{
 pub struct OwnedLazyValue {
     // the raw slice from origin json
     pub(crate) raw: FastStr,
-    unescape: Option<Arc<String>>,
+    unescape: Option<Arc<str>>,
 }
 
 impl PartialEq for OwnedLazyValue {
@@ -122,7 +122,7 @@ impl JsonValueTrait for OwnedLazyValue {
         if !self.is_str() {
             None
         } else if let Some(escaped) = self.unescape.as_ref() {
-            Some(escaped.as_str())
+            Some(escaped.as_ref())
         } else {
             // remove the quotes
             let origin = {
@@ -224,16 +224,13 @@ impl OwnedLazyValue {
             JsonSlice::Raw(r) => FastStr::new(unsafe { from_utf8_unchecked(r) }),
             JsonSlice::FastStr(f) => f.clone(),
         };
-        let escaped = if has_escaped {
-            let unescaped: String = crate::from_str(raw.as_str())?;
-            Some(Arc::new(unescaped))
+        let unescape = if has_escaped {
+            let unescape: Arc<str> = unsafe { crate::from_slice_unchecked(raw.as_ref()) }?;
+            Some(unescape)
         } else {
             None
         };
-        Ok(Self {
-            raw,
-            unescape: escaped,
-        })
+        Ok(Self { raw, unescape })
     }
 }
 

--- a/src/lazyvalue/ser.rs
+++ b/src/lazyvalue/ser.rs
@@ -1,7 +1,6 @@
-use ::serde::{ser::SerializeStruct, Serialize};
+use ::serde::ser::SerializeStruct;
 
 use super::{owned::OwnedLazyValue, value::LazyValue};
-use crate::Result;
 
 impl<'a> serde::ser::Serialize for LazyValue<'a> {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -27,24 +26,6 @@ impl serde::ser::Serialize for OwnedLazyValue {
         s.serialize_field(super::TOKEN, raw)?;
         s.end()
     }
-}
-
-/// Convert a `T: Serialize` into a `LazyValue`.
-pub fn to_lazyvalue<'a, T>(value: &T) -> Result<LazyValue<'a>>
-where
-    T: ?Sized + Serialize,
-{
-    let json_string = crate::to_string(value)?;
-    Ok(LazyValue::new(json_string.into()))
-}
-
-/// Convert a `T: Serialize` into a `OwnedLazyValue`.
-pub fn to_ownedlazyvalue<T>(value: &T) -> Result<OwnedLazyValue>
-where
-    T: ?Sized + Serialize,
-{
-    let json_string = crate::to_string(value)?;
-    Ok(OwnedLazyValue::new(json_string.into()))
 }
 
 #[cfg(test)]

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -63,7 +63,7 @@ use crate::{
 pub struct LazyValue<'a> {
     // the raw slice from origin json
     pub(crate) raw: JsonSlice<'a>,
-    pub(crate) unescape: Option<Arc<String>>,
+    pub(crate) unescape: Option<Arc<str>>,
 }
 
 impl Default for LazyValue<'_> {
@@ -133,7 +133,7 @@ impl<'a> JsonValueTrait for LazyValue<'a> {
         if !self.is_str() {
             None
         } else if let Some(escaped) = self.unescape.as_ref() {
-            Some(escaped.as_str())
+            Some(escaped.as_ref())
         } else {
             // remove the quotes
             let origin = {
@@ -264,16 +264,13 @@ impl<'a> LazyValue<'a> {
     }
 
     pub(crate) fn new(raw: JsonSlice<'a>, has_escaped: bool) -> Result<Self> {
-        let escaped = if has_escaped {
-            let unescaped: String = unsafe { crate::from_slice_unchecked(raw.as_ref()) }?;
-            Some(Arc::new(unescaped))
+        let unescape = if has_escaped {
+            let unescape: Arc<str> = unsafe { crate::from_slice_unchecked(raw.as_ref()) }?;
+            Some(unescape)
         } else {
             None
         };
-        Ok(Self {
-            raw,
-            unescape: escaped,
-        })
+        Ok(Self { raw, unescape })
     }
 }
 

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -14,7 +14,7 @@ use crate::{
         ErrorCode::{self, EofWhileParsing, RecursionLimitExceeded},
         Result,
     },
-    parser::{as_str, Parser},
+    parser::{as_str, ParseStatus, Parser},
     reader::{Reader, Reference, SliceRead},
     util::num::ParserNumber,
     value::node::Value,
@@ -185,8 +185,12 @@ impl<'de, R: Reader<'de>> Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let raw = as_str(self.parser.skip_one()?);
-        visitor.visit_borrowed_str(raw)
+        let (raw, status) = self.parser.skip_one()?;
+        if status == ParseStatus::HasEsacped {
+            visitor.visit_str(as_str(raw))
+        } else {
+            visitor.visit_borrowed_str(as_str(raw))
+        }
     }
 
     fn deserialize_value<V>(&mut self, visitor: V) -> Result<V::Value>

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -52,7 +52,6 @@ use crate::{
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
-///
 pub fn from_value<'de, T>(value: &'de Value) -> Result<T, Error>
 where
     T: Deserialize<'de>,


### PR DESCRIPTION
Origin `LazyValue` has a `UnsafeCell`, to be used for parsing string which has escaped chars. This makes the parsing lazy but also makes it `!Sync`.


In the new `LazyValue`, we will first parse the string which has escaped chars and store it in the `Arc<str>`. It will be `Sync`.