### PR TITLE
feat: Add runtime detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +888,7 @@ dependencies = [
  "chrono",
  "core_affinity",
  "criterion",
+ "derive_more",
  "faststr",
  "gjson",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["encoding", "parser-implementations"]
 
 [dependencies]
 cfg-if = "1.0"
+derive_more = { version = "1.0.0-beta.6", features = ["from"] }
 arrayref = "0.3"
 serde = { version = "1.0", features = ["rc", "derive"] }
 itoa = "1.0"
@@ -76,4 +77,5 @@ name = "get_from"
 harness = false
 
 [features]
-default = []
+default = ["runtime-detection"]
+runtime-detection = []

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ A fast Rust JSON library based on SIMD. It has some references to other open-sou
 
 2. ~~Requires Rust nightly version~~ Support Stable Rust now.
 
-3. Please add the compile options `-C target-cpu=native`
+3. Please add the compile options `-C target-cpu=native` (unless you enable the `runtime-dispatch` feature).
 
 ## Quick to use sonic-rs
 
-To ensure that SIMD instruction is used in sonic-rs, you need to add rustflags `-C target-cpu=native` and compile on the host machine. For example, Rust flags can be configured in Cargo [config](.cargo/config).
+~~To ensure that SIMD instruction is used in sonic-rs, you need to add rustflags `-C target-cpu=native` and compile on the host machine. For example, Rust flags can be configured in Cargo [config](.cargo/config).~~
 
 Add sonic-rs in `Cargo.toml`
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -55,6 +55,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "derive_more"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "faststr"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +255,7 @@ dependencies = [
  "bumpalo",
  "bytes",
  "cfg-if",
+ "derive_more",
  "faststr",
  "itoa",
  "page_size",

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -11,37 +11,52 @@ macro_rules! impl_lanes {
     };
 }
 
-// pick v128 simd
 cfg_if::cfg_if! {
-    if #[cfg(target_feature = "sse2")] {
+    if #[cfg(target_arch = "x86_64")] {
+        mod avx2;
         mod sse2;
-        use self::sse2::*;
-    } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+    } else if #[cfg(target_arch = "aarch64")] {
         pub(crate) mod neon;
-        use self::neon::*;
-    } else {
-        // TODO: support wasm
-        mod v128;
-        use self::v128::*;
     }
 }
 
-// pick v256 simd
-cfg_if::cfg_if! {
-    if #[cfg(target_feature = "avx2")] {
-        mod avx2;
-        use self::avx2::*;
-    } else {
-        mod v256;
-        use self::v256::*;
-    }
-}
+mod v128;
+mod v256;
+mod v512;
 
 pub use self::traits::{Mask, Simd};
-// pick v512 simd
-// TODO: support avx512?
-mod v512;
-use self::v512::*;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "runtime-detection")] {
+        mod runtime_dispatch;
+        pub use self::runtime_dispatch::*;
+    } else {
+        // pick v128 simd
+        cfg_if::cfg_if! {
+            if #[cfg(target_feature = "sse2")] {
+                use self::sse2::*;
+            } else if #[cfg(target_arch="aarch64")] {
+                use self::neon::*;
+            } else {
+                // TODO: support wasm
+                use self::v128::*;
+            }
+        }
+
+        // pick v256 simd
+        cfg_if::cfg_if! {
+            if #[cfg(target_feature = "avx2")] {
+                use self::avx2::*;
+            } else {
+                use self::v256::*;
+            }
+        }
+
+        // pick v512 simd
+        // TODO: support avx512?
+        use self::v512::*;
+    }
+}
 
 pub type u8x16 = Simd128i;
 pub type u8x32 = Simd256u;

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -35,7 +35,7 @@ cfg_if::cfg_if! {
         cfg_if::cfg_if! {
             if #[cfg(target_feature = "sse2")] {
                 use self::sse2::*;
-            } else if #[cfg(target_arch="aarch64")] {
+            } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
                 use self::neon::*;
             } else {
                 // TODO: support wasm

--- a/src/util/simd/runtime_dispatch/d128.rs
+++ b/src/util/simd/runtime_dispatch/d128.rs
@@ -28,7 +28,9 @@ impl Simd for Simd128i {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::loadu(ptr));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::loadu(ptr));
+        }
 
         Self::Fallback(Simd::loadu(ptr))
     }
@@ -64,7 +66,9 @@ impl Simd for Simd128i {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::splat(ch));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::splat(ch));
+        }
 
         Self::Fallback(Simd::splat(ch))
     }
@@ -115,7 +119,9 @@ impl Simd for Simd128u {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::loadu(ptr));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::loadu(ptr));
+        }
 
         Self::Fallback(Simd::loadu(ptr))
     }
@@ -151,7 +157,9 @@ impl Simd for Simd128u {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::splat(ch));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::splat(ch));
+        }
 
         Self::Fallback(Simd::splat(ch))
     }
@@ -210,7 +218,9 @@ impl Mask for Mask128 {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Mask::splat(b));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Mask::splat(b));
+        }
 
         Self::Fallback(Mask::splat(b))
     }

--- a/src/util/simd/runtime_dispatch/d128.rs
+++ b/src/util/simd/runtime_dispatch/d128.rs
@@ -234,7 +234,7 @@ impl BitAnd for Mask128 {
             #[cfg(target_arch = "x86_64")]
             (Self::Sse2(lhs), Self::Sse2(rhs)) => lhs.bitand(rhs).into(),
             #[cfg(target_arch = "aarch64")]
-            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitand(rhs).into(),
+            (Self::Neon(lhs), Self::Neon(rhs)) => lhs.bitand(rhs).into(),
             (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitand(rhs).into(),
             _ => unreachable!(),
         }
@@ -249,7 +249,7 @@ impl BitOr for Mask128 {
             #[cfg(target_arch = "x86_64")]
             (Self::Sse2(lhs), Self::Sse2(rhs)) => lhs.bitor(rhs).into(),
             #[cfg(target_arch = "aarch64")]
-            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor(rhs).into(),
+            (Self::Neon(lhs), Self::Neon(rhs)) => lhs.bitor(rhs).into(),
             (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor(rhs).into(),
             _ => unreachable!(),
         }
@@ -262,7 +262,7 @@ impl BitOrAssign for Mask128 {
             #[cfg(target_arch = "x86_64")]
             (Self::Sse2(lhs), Self::Sse2(rhs)) => lhs.bitor_assign(rhs),
             #[cfg(target_arch = "aarch64")]
-            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor_assign(rhs),
+            (Self::Neon(lhs), Self::Neon(rhs)) => lhs.bitor_assign(rhs),
             (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor_assign(rhs),
             _ => unreachable!(),
         };

--- a/src/util/simd/runtime_dispatch/d128.rs
+++ b/src/util/simd/runtime_dispatch/d128.rs
@@ -23,12 +23,12 @@ impl Simd for Simd128i {
     #[inline(always)]
     unsafe fn loadu(ptr: *const u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("sse2") {
+        if std::arch::is_x86_feature_detected!("sse2") {
             return Self::Sse2(Simd::loadu(ptr));
         }
 
         #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             return Self::Neon(Simd::loadu(ptr));
         }
 
@@ -61,12 +61,12 @@ impl Simd for Simd128i {
     #[inline(always)]
     fn splat(ch: u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("sse2") {
+        if std::arch::is_x86_feature_detected!("sse2") {
             return Self::Sse2(Simd::splat(ch));
         }
 
         #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             return Self::Neon(Simd::splat(ch));
         }
 
@@ -114,12 +114,12 @@ impl Simd for Simd128u {
     #[inline(always)]
     unsafe fn loadu(ptr: *const u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("sse2") {
+        if std::arch::is_x86_feature_detected!("sse2") {
             return Self::Sse2(Simd::loadu(ptr));
         }
 
         #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             return Self::Neon(Simd::loadu(ptr));
         }
 
@@ -152,12 +152,12 @@ impl Simd for Simd128u {
     #[inline(always)]
     fn splat(ch: u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("sse2") {
+        if std::arch::is_x86_feature_detected!("sse2") {
             return Self::Sse2(Simd::splat(ch));
         }
 
         #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             return Self::Neon(Simd::splat(ch));
         }
 
@@ -213,12 +213,12 @@ impl Mask for Mask128 {
 
     fn splat(b: bool) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("sse2") {
+        if std::arch::is_x86_feature_detected!("sse2") {
             return Self::Sse2(Mask::splat(b));
         }
 
         #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
+        if std::arch::is_aarch64_feature_detected!("neon") {
             return Self::Neon(Mask::splat(b));
         }
 

--- a/src/util/simd/runtime_dispatch/d128.rs
+++ b/src/util/simd/runtime_dispatch/d128.rs
@@ -1,0 +1,260 @@
+use std::ops::{BitAnd, BitOr, BitOrAssign};
+
+use derive_more::From;
+
+use crate::util::simd::{self, Mask, Simd};
+
+impl_lanes!(Simd128u, 16);
+impl_lanes!(Mask128, 16);
+
+#[derive(Debug)]
+pub enum Simd128i {
+    #[cfg(target_arch = "x86_64")]
+    Sse2(simd::sse2::Simd128i),
+    #[cfg(target_arch = "aarch64")]
+    Neon(simd::neon::Simd128i),
+    Fallback(simd::v128::Simd128i),
+}
+
+impl Simd for Simd128i {
+    const LANES: usize = 16;
+    type Mask = Mask128;
+
+    #[inline(always)]
+    unsafe fn loadu(ptr: *const u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("sse2") {
+            return Self::Sse2(Simd::loadu(ptr));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::loadu(ptr));
+
+        Self::Fallback(Simd::loadu(ptr))
+    }
+
+    #[inline(always)]
+    unsafe fn storeu(&self, ptr: *mut u8) {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Sse2(sse2) => sse2.storeu(ptr),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon(neon) => neon.storeu(ptr),
+            Self::Fallback(fallback) => fallback.storeu(ptr),
+        }
+    }
+
+    #[inline(always)]
+    fn eq(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(rhs), Self::Sse2(lhs)) => rhs.eq(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.eq(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.eq(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn splat(ch: u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("sse2") {
+            return Self::Sse2(Simd::splat(ch));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::splat(ch));
+
+        Self::Fallback(Simd::splat(ch))
+    }
+
+    #[inline(always)]
+    fn le(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(rhs), Self::Sse2(lhs)) => rhs.le(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.le(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.le(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn gt(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(rhs), Self::Sse2(lhs)) => rhs.gt(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.gt(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.gt(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Simd128u {
+    #[cfg(target_arch = "x86_64")]
+    Sse2(simd::sse2::Simd128u),
+    #[cfg(target_arch = "aarch64")]
+    Neon(simd::neon::Simd128u),
+    Fallback(simd::v128::Simd128u),
+}
+
+impl Simd for Simd128u {
+    const LANES: usize = 16;
+    type Mask = Mask128;
+
+    #[inline(always)]
+    unsafe fn loadu(ptr: *const u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("sse2") {
+            return Self::Sse2(Simd::loadu(ptr));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::loadu(ptr));
+
+        Self::Fallback(Simd::loadu(ptr))
+    }
+
+    #[inline(always)]
+    unsafe fn storeu(&self, ptr: *mut u8) {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Sse2(sse2) => sse2.storeu(ptr),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon(neon) => neon.storeu(ptr),
+            Self::Fallback(fallback) => fallback.storeu(ptr),
+        }
+    }
+
+    #[inline(always)]
+    fn eq(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(rhs), Self::Sse2(lhs)) => rhs.eq(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.eq(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.eq(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn splat(ch: u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("sse2") {
+            return Self::Sse2(Simd::splat(ch));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::splat(ch));
+
+        Self::Fallback(Simd::splat(ch))
+    }
+
+    #[inline(always)]
+    fn le(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(rhs), Self::Sse2(lhs)) => rhs.le(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.le(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.le(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn gt(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(rhs), Self::Sse2(lhs)) => rhs.gt(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.gt(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.gt(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, From)]
+pub enum Mask128 {
+    #[cfg(target_arch = "x86_64")]
+    Sse2(simd::sse2::Mask128),
+    #[cfg(target_arch = "aarch64")]
+    Neon(simd::neon::Mask128),
+    Fallback(simd::v128::Mask128),
+}
+
+impl Mask for Mask128 {
+    type BitMap = u16;
+
+    fn bitmask(self) -> Self::BitMap {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Sse2(sse2) => sse2.bitmask(),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon(neon) => neon.bitmask(),
+            Self::Fallback(fallback) => fallback.bitmask(),
+        }
+    }
+
+    fn splat(b: bool) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("sse2") {
+            return Self::Sse2(Mask::splat(b));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Mask::splat(b));
+
+        Self::Fallback(Mask::splat(b))
+    }
+}
+
+impl BitAnd for Mask128 {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(lhs), Self::Sse2(rhs)) => lhs.bitand(rhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitand(rhs).into(),
+            (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitand(rhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl BitOr for Mask128 {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(lhs), Self::Sse2(rhs)) => lhs.bitor(rhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor(rhs).into(),
+            (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor(rhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl BitOrAssign for Mask128 {
+    fn bitor_assign(&mut self, rhs: Self) {
+        match (self, rhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Sse2(lhs), Self::Sse2(rhs)) => lhs.bitor_assign(rhs),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor_assign(rhs),
+            (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor_assign(rhs),
+            _ => unreachable!(),
+        };
+    }
+}

--- a/src/util/simd/runtime_dispatch/d256.rs
+++ b/src/util/simd/runtime_dispatch/d256.rs
@@ -1,0 +1,260 @@
+use std::ops::{BitAnd, BitOr, BitOrAssign};
+
+use derive_more::From;
+
+use crate::util::simd::{self, Mask, Simd};
+
+impl_lanes!(Simd256u, 32);
+impl_lanes!(Mask256, 32);
+
+#[derive(Debug)]
+pub enum Simd256i {
+    #[cfg(target_arch = "x86_64")]
+    Avx2(simd::avx2::Simd256i),
+    #[cfg(target_arch = "aarch64")]
+    Neon(simd::neon::Simd256i),
+    Fallback(simd::v256::Simd256i),
+}
+
+impl Simd for Simd256i {
+    const LANES: usize = 16;
+    type Mask = Mask256;
+
+    #[inline(always)]
+    unsafe fn loadu(ptr: *const u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx2") {
+            return Self::Avx2(Simd::loadu(ptr));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::loadu(ptr));
+
+        Self::Fallback(Simd::loadu(ptr))
+    }
+
+    #[inline(always)]
+    unsafe fn storeu(&self, ptr: *mut u8) {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx2(avx2) => avx2.storeu(ptr),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon(neon) => neon.storeu(ptr),
+            Self::Fallback(fallback) => fallback.storeu(ptr),
+        }
+    }
+
+    #[inline(always)]
+    fn eq(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.eq(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.eq(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.eq(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn splat(ch: u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx2") {
+            return Self::Avx2(Simd::splat(ch));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::splat(ch));
+
+        Self::Fallback(Simd::splat(ch))
+    }
+
+    #[inline(always)]
+    fn le(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.le(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.le(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.le(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn gt(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.gt(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.gt(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.gt(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Simd256u {
+    #[cfg(target_arch = "x86_64")]
+    Avx2(simd::avx2::Simd256u),
+    #[cfg(target_arch = "aarch64")]
+    Neon(simd::neon::Simd256u),
+    Fallback(simd::v256::Simd256u),
+}
+
+impl Simd for Simd256u {
+    const LANES: usize = 16;
+    type Mask = Mask256;
+
+    #[inline(always)]
+    unsafe fn loadu(ptr: *const u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx2") {
+            return Self::Avx2(Simd::loadu(ptr));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::loadu(ptr));
+
+        Self::Fallback(Simd::loadu(ptr))
+    }
+
+    #[inline(always)]
+    unsafe fn storeu(&self, ptr: *mut u8) {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx2(avx2) => avx2.storeu(ptr),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon(neon) => neon.storeu(ptr),
+            Self::Fallback(fallback) => fallback.storeu(ptr),
+        }
+    }
+
+    #[inline(always)]
+    fn eq(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.eq(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.eq(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.eq(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn splat(ch: u8) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx2") {
+            return Self::Avx2(Simd::splat(ch));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Simd::splat(ch));
+
+        Self::Fallback(Simd::splat(ch))
+    }
+
+    #[inline(always)]
+    fn le(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.le(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.le(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.le(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline(always)]
+    fn gt(&self, lhs: &Self) -> Self::Mask {
+        match (self, lhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.gt(lhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.gt(lhs).into(),
+            (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.gt(lhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, From)]
+pub enum Mask256 {
+    #[cfg(target_arch = "x86_64")]
+    Avx2(simd::avx2::Mask256),
+    #[cfg(target_arch = "aarch64")]
+    Neon(simd::neon::Mask256),
+    Fallback(simd::v256::Mask256),
+}
+
+impl Mask for Mask256 {
+    type BitMap = u32;
+
+    fn bitmask(self) -> Self::BitMap {
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx2(avx2) => avx2.bitmask(),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon(neon) => neon.bitmask(),
+            Self::Fallback(fallback) => fallback.bitmask(),
+        }
+    }
+
+    fn splat(b: bool) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("avx2") {
+            return Self::Avx2(Mask::splat(b));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        return Self::Neon(Mask::splat(b));
+
+        Self::Fallback(Mask::splat(b))
+    }
+}
+
+impl BitAnd for Mask256 {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(lhs), Self::Avx2(rhs)) => lhs.bitand(rhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitand(rhs).into(),
+            (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitand(rhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl BitOr for Mask256 {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(lhs), Self::Avx2(rhs)) => lhs.bitor(rhs).into(),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor(rhs).into(),
+            (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor(rhs).into(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl BitOrAssign for Mask256 {
+    fn bitor_assign(&mut self, rhs: Self) {
+        match (self, rhs) {
+            #[cfg(target_arch = "x86_64")]
+            (Self::Avx2(lhs), Self::Avx2(rhs)) => lhs.bitor_assign(rhs),
+            #[cfg(target_arch = "aarch64")]
+            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor_assign(rhs),
+            (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor_assign(rhs),
+            _ => unreachable!(),
+        };
+    }
+}

--- a/src/util/simd/runtime_dispatch/d256.rs
+++ b/src/util/simd/runtime_dispatch/d256.rs
@@ -28,7 +28,9 @@ impl Simd for Simd256i {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::loadu(ptr));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::loadu(ptr));
+        }
 
         Self::Fallback(Simd::loadu(ptr))
     }
@@ -64,7 +66,9 @@ impl Simd for Simd256i {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::splat(ch));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::splat(ch));
+        }
 
         Self::Fallback(Simd::splat(ch))
     }
@@ -115,7 +119,9 @@ impl Simd for Simd256u {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::loadu(ptr));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::loadu(ptr));
+        }
 
         Self::Fallback(Simd::loadu(ptr))
     }
@@ -151,7 +157,9 @@ impl Simd for Simd256u {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Simd::splat(ch));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Simd::splat(ch));
+        }
 
         Self::Fallback(Simd::splat(ch))
     }
@@ -210,7 +218,9 @@ impl Mask for Mask256 {
         }
 
         #[cfg(target_arch = "aarch64")]
-        return Self::Neon(Mask::splat(b));
+        if is_aarch64_feature_detected!("neon") {
+            return Self::Neon(Mask::splat(b));
+        }
 
         Self::Fallback(Mask::splat(b))
     }

--- a/src/util/simd/runtime_dispatch/d256.rs
+++ b/src/util/simd/runtime_dispatch/d256.rs
@@ -11,8 +11,6 @@ impl_lanes!(Mask256, 32);
 pub enum Simd256i {
     #[cfg(target_arch = "x86_64")]
     Avx2(simd::avx2::Simd256i),
-    #[cfg(target_arch = "aarch64")]
-    Neon(simd::neon::Simd256i),
     Fallback(simd::v256::Simd256i),
 }
 
@@ -27,11 +25,6 @@ impl Simd for Simd256i {
             return Self::Avx2(Simd::loadu(ptr));
         }
 
-        #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
-            return Self::Neon(Simd::loadu(ptr));
-        }
-
         Self::Fallback(Simd::loadu(ptr))
     }
 
@@ -40,8 +33,6 @@ impl Simd for Simd256i {
         match self {
             #[cfg(target_arch = "x86_64")]
             Self::Avx2(avx2) => avx2.storeu(ptr),
-            #[cfg(target_arch = "aarch64")]
-            Self::Neon(neon) => neon.storeu(ptr),
             Self::Fallback(fallback) => fallback.storeu(ptr),
         }
     }
@@ -51,8 +42,6 @@ impl Simd for Simd256i {
         match (self, lhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.eq(lhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.eq(lhs).into(),
             (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.eq(lhs).into(),
             _ => unreachable!(),
         }
@@ -65,11 +54,6 @@ impl Simd for Simd256i {
             return Self::Avx2(Simd::splat(ch));
         }
 
-        #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
-            return Self::Neon(Simd::splat(ch));
-        }
-
         Self::Fallback(Simd::splat(ch))
     }
 
@@ -78,8 +62,6 @@ impl Simd for Simd256i {
         match (self, lhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.le(lhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.le(lhs).into(),
             (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.le(lhs).into(),
             _ => unreachable!(),
         }
@@ -90,8 +72,6 @@ impl Simd for Simd256i {
         match (self, lhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.gt(lhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.gt(lhs).into(),
             (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.gt(lhs).into(),
             _ => unreachable!(),
         }
@@ -102,8 +82,6 @@ impl Simd for Simd256i {
 pub enum Simd256u {
     #[cfg(target_arch = "x86_64")]
     Avx2(simd::avx2::Simd256u),
-    #[cfg(target_arch = "aarch64")]
-    Neon(simd::neon::Simd256u),
     Fallback(simd::v256::Simd256u),
 }
 
@@ -118,11 +96,6 @@ impl Simd for Simd256u {
             return Self::Avx2(Simd::loadu(ptr));
         }
 
-        #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
-            return Self::Neon(Simd::loadu(ptr));
-        }
-
         Self::Fallback(Simd::loadu(ptr))
     }
 
@@ -131,8 +104,6 @@ impl Simd for Simd256u {
         match self {
             #[cfg(target_arch = "x86_64")]
             Self::Avx2(avx2) => avx2.storeu(ptr),
-            #[cfg(target_arch = "aarch64")]
-            Self::Neon(neon) => neon.storeu(ptr),
             Self::Fallback(fallback) => fallback.storeu(ptr),
         }
     }
@@ -142,8 +113,6 @@ impl Simd for Simd256u {
         match (self, lhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.eq(lhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.eq(lhs).into(),
             (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.eq(lhs).into(),
             _ => unreachable!(),
         }
@@ -156,11 +125,6 @@ impl Simd for Simd256u {
             return Self::Avx2(Simd::splat(ch));
         }
 
-        #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
-            return Self::Neon(Simd::splat(ch));
-        }
-
         Self::Fallback(Simd::splat(ch))
     }
 
@@ -169,8 +133,6 @@ impl Simd for Simd256u {
         match (self, lhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.le(lhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.le(lhs).into(),
             (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.le(lhs).into(),
             _ => unreachable!(),
         }
@@ -181,8 +143,6 @@ impl Simd for Simd256u {
         match (self, lhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(rhs), Self::Avx2(lhs)) => rhs.gt(lhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(rhs), Self::Neon(lhs)) => rhs.gt(lhs).into(),
             (Self::Fallback(rhs), Self::Fallback(lhs)) => rhs.gt(lhs).into(),
             _ => unreachable!(),
         }
@@ -193,8 +153,6 @@ impl Simd for Simd256u {
 pub enum Mask256 {
     #[cfg(target_arch = "x86_64")]
     Avx2(simd::avx2::Mask256),
-    #[cfg(target_arch = "aarch64")]
-    Neon(simd::neon::Mask256),
     Fallback(simd::v256::Mask256),
 }
 
@@ -205,8 +163,6 @@ impl Mask for Mask256 {
         match self {
             #[cfg(target_arch = "x86_64")]
             Self::Avx2(avx2) => avx2.bitmask(),
-            #[cfg(target_arch = "aarch64")]
-            Self::Neon(neon) => neon.bitmask(),
             Self::Fallback(fallback) => fallback.bitmask(),
         }
     }
@@ -215,11 +171,6 @@ impl Mask for Mask256 {
         #[cfg(target_arch = "x86_64")]
         if is_x86_feature_detected!("avx2") {
             return Self::Avx2(Mask::splat(b));
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        if is_aarch64_feature_detected!("neon") {
-            return Self::Neon(Mask::splat(b));
         }
 
         Self::Fallback(Mask::splat(b))
@@ -233,8 +184,6 @@ impl BitAnd for Mask256 {
         match (self, rhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(lhs), Self::Avx2(rhs)) => lhs.bitand(rhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitand(rhs).into(),
             (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitand(rhs).into(),
             _ => unreachable!(),
         }
@@ -248,8 +197,6 @@ impl BitOr for Mask256 {
         match (self, rhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(lhs), Self::Avx2(rhs)) => lhs.bitor(rhs).into(),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor(rhs).into(),
             (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor(rhs).into(),
             _ => unreachable!(),
         }
@@ -261,8 +208,6 @@ impl BitOrAssign for Mask256 {
         match (self, rhs) {
             #[cfg(target_arch = "x86_64")]
             (Self::Avx2(lhs), Self::Avx2(rhs)) => lhs.bitor_assign(rhs),
-            #[cfg(target_arch = "aarch64")]
-            (Self::Neon(lhs), Self::Sse(rhs)) => lhs.bitor_assign(rhs),
             (Self::Fallback(lhs), Self::Fallback(rhs)) => lhs.bitor_assign(rhs),
             _ => unreachable!(),
         };

--- a/src/util/simd/runtime_dispatch/d256.rs
+++ b/src/util/simd/runtime_dispatch/d256.rs
@@ -21,7 +21,7 @@ impl Simd for Simd256i {
     #[inline(always)]
     unsafe fn loadu(ptr: *const u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             return Self::Avx2(Simd::loadu(ptr));
         }
 
@@ -50,7 +50,7 @@ impl Simd for Simd256i {
     #[inline(always)]
     fn splat(ch: u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             return Self::Avx2(Simd::splat(ch));
         }
 
@@ -92,7 +92,7 @@ impl Simd for Simd256u {
     #[inline(always)]
     unsafe fn loadu(ptr: *const u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             return Self::Avx2(Simd::loadu(ptr));
         }
 
@@ -121,7 +121,7 @@ impl Simd for Simd256u {
     #[inline(always)]
     fn splat(ch: u8) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             return Self::Avx2(Simd::splat(ch));
         }
 
@@ -169,7 +169,7 @@ impl Mask for Mask256 {
 
     fn splat(b: bool) -> Self {
         #[cfg(target_arch = "x86_64")]
-        if is_x86_feature_detected!("avx2") {
+        if std::arch::is_x86_feature_detected!("avx2") {
             return Self::Avx2(Mask::splat(b));
         }
 

--- a/src/util/simd/runtime_dispatch/mod.rs
+++ b/src/util/simd/runtime_dispatch/mod.rs
@@ -1,0 +1,7 @@
+mod d128;
+mod d256;
+
+pub use self::{d128::*, d256::*};
+// pick v512 simd
+// TODO: support avx512?
+pub use super::v512::*;


### PR DESCRIPTION
#### What type of PR is this?

feat: A new feature
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

~~- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)~~


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

This PR implements runtime detection of the SSE2, NEON, and AVX2 features, queried via the `is_x86_feature_enabled` and `is_aarch64_feature_enabled` macros (gated behind the `runtime-detection` macro).


#### (Optional) Which issue(s) this PR fixes:

Closes #14 

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
