### PR TITLE
opt: use faster NEON bitmask and fix skip number bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
 dependencies = [
  "cfg-if",
  "once_cell",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! When serializing or deserializing JSON goes wrong.
+//! Errors.
 
 // The code is cloned from [serde_json](https://github.com/serde-rs/json) and modified necessary parts.
 

--- a/src/lazyvalue/get.rs
+++ b/src/lazyvalue/get.rs
@@ -487,9 +487,9 @@ mod test {
         }
 
         test_get_ok(
-            r#"1230(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"#,
+            r#"1230/(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"#,
             &pointer![],
-            r#"1230("#,
+            r#"1230"#,
         );
 
         test_get_ok(

--- a/src/lazyvalue/get.rs
+++ b/src/lazyvalue/get.rs
@@ -487,6 +487,12 @@ mod test {
         }
 
         test_get_ok(
+            r#"1230(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"#,
+            &pointer![],
+            r#"1230("#,
+        );
+
+        test_get_ok(
             r#"{"a":"\n\tHello,\nworld!\n"}"#,
             &pointer!["a"],
             r#""\n\tHello,\nworld!\n""#,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1424,8 +1424,8 @@ where
         // SIMD path for long number
         while let Some(chunk) = self.read.peek_n(32) {
             let v = unsafe { i8x32::from_slice_unaligned_unchecked(chunk) };
-            let less0 = i8x32::splat(b'0' - 1);
-            let nine = i8x32::splat(b'9');
+            let less0 = i8x32::splat((b'0' - 1) as i8);
+            let nine = i8x32::splat(b'9' as i8);
             let nondigits = (v.le(&less0) | v.gt(&nine)).bitmask();
 
             if nondigits != 0 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use smallvec::SmallVec;
 
 use super::reader::{Reader, Reference};
 #[cfg(all(target_feature = "neon", target_arch = "aarch64"))]
-use crate::util::simd::{bits::NeonBits, u8x16};
+use crate::util::simd::bits::NeonBits;
 use crate::{
     error::{
         Error,

--- a/src/util/arch/aarch64.rs
+++ b/src/util/arch/aarch64.rs
@@ -68,32 +68,12 @@ pub unsafe fn get_nonspace_bits(data: &[u8; 64]) -> u64 {
         vtstq_u8(v, white_mask)
     }
 
-    let input = (
+    !crate::util::simd::neon::to_bitmask64(
         chunk_nonspace_bits(vld1q_u8(data.as_ptr())),
         chunk_nonspace_bits(vld1q_u8(data.as_ptr().offset(16))),
         chunk_nonspace_bits(vld1q_u8(data.as_ptr().offset(32))),
         chunk_nonspace_bits(vld1q_u8(data.as_ptr().offset(48))),
-    );
-
-    let mask64 = crate::util::simd::neon::to_bitmask64(input);
-    !mask64
-
-    // Equal C++ code as:
-    // const simd8<uint8_t> table1(16, 0, 0, 0, 0, 0, 0, 0, 0, 8, 12, 1, 2, 9, 0, 0);
-    // const simd8<uint8_t> table2(8, 0, 18, 4, 0, 1, 0, 1, 0, 0, 0, 3, 2, 1, 0, 0);
-    // simd8x64<uint8_t> v(
-    //    (in.chunks[0] & 0xf).lookup_16(table1) & (in.chunks[0].shr<4>()).lookup_16(table2),
-    //    (in.chunks[1] & 0xf).lookup_16(table1) & (in.chunks[1].shr<4>()).lookup_16(table2),
-    //    (in.chunks[2] & 0xf).lookup_16(table1) & (in.chunks[2].shr<4>()).lookup_16(table2),
-    //    (in.chunks[3] & 0xf).lookup_16(table1) & (in.chunks[3].shr<4>()).lookup_16(table2)
-    // );
-    //     uint64_t whitespace = simd8x64<bool>(
-    //         v.chunks[0].any_bits_set(0x18),
-    //         v.chunks[1].any_bits_set(0x18),
-    //         v.chunks[2].any_bits_set(0x18),
-    //         v.chunks[3].any_bits_set(0x18)
-    //   ).to_bitmask();
-    //   return { whitespace, op };
+    )
 }
 
 #[inline(always)]

--- a/src/util/simd/avx2.rs
+++ b/src/util/simd/avx2.rs
@@ -61,11 +61,11 @@ impl_lanes!(Simd256u, 32);
 impl_lanes!(Mask256, 32);
 
 impl Mask for Mask256 {
-    type Bitmap = u32;
+    type BitMask = u32;
     type Element = u8;
 
     #[inline(always)]
-    fn bitmask(self) -> Self::Bitmap {
+    fn bitmask(self) -> Self::BitMask {
         unsafe { _mm256_movemask_epi8(self.0) as u32 }
     }
 

--- a/src/util/simd/avx2.rs
+++ b/src/util/simd/avx2.rs
@@ -40,13 +40,12 @@ impl Simd for Simd256i {
         unsafe { Self(_mm256_set1_epi8(elem)) }
     }
 
-    // less or equal
     #[inline(always)]
     fn le(&self, rhs: &Self) -> Self::Mask {
-        unsafe { Mask256(_mm256_cmpgt_epi8(rhs.0, self.0)) }
+        // self <= rhs equal as rhs >= self
+        rhs.gt(self) | rhs.eq(self)
     }
 
-    // greater than
     #[inline(always)]
     fn gt(&self, rhs: &Self) -> Self::Mask {
         unsafe { Mask256(_mm256_cmpgt_epi8(self.0, rhs.0)) }
@@ -130,7 +129,6 @@ impl Simd for Simd256u {
         unsafe { Simd256u(_mm256_set1_epi8(ch as i8)) }
     }
 
-    // less or equal
     #[inline(always)]
     fn le(&self, rhs: &Self) -> Self::Mask {
         unsafe {
@@ -140,7 +138,6 @@ impl Simd for Simd256u {
         }
     }
 
-    // greater than
     #[inline(always)]
     fn gt(&self, _rhs: &Self) -> Self::Mask {
         todo!()

--- a/src/util/simd/bits.rs
+++ b/src/util/simd/bits.rs
@@ -1,0 +1,94 @@
+use super::traits::BitMask;
+
+macro_rules! impl_bits {
+    () => {};
+    ($($ty:ty)*) => {
+        $(
+            impl BitMask for $ty {
+                const LEN: usize = std::mem::size_of::<$ty>() * 8;
+
+                #[inline]
+                fn before(&self, rhs: &Self) -> bool {
+                    (self.as_little_endian()  & rhs.as_little_endian().wrapping_sub(1)) != 0
+                }
+
+                #[inline]
+                fn first_offset(&self) -> usize {
+                    self.as_little_endian().trailing_zeros() as usize
+                }
+
+                #[inline]
+                fn as_little_endian(&self) -> Self {
+                    #[cfg(target_endian = "little")]
+                    {
+                        self.clone()
+                    }
+                    #[cfg(target_endian = "big")]
+                    {
+                        self.swap_bytes()
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl_bits!(u16 u32 u64);
+
+pub struct NeonBits(u64);
+
+impl NeonBits {
+    #[inline]
+    pub fn new(u: u64) -> Self {
+        Self(u)
+    }
+}
+
+impl BitMask for NeonBits {
+    const LEN: usize = 8;
+
+    /// reference: https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
+    #[inline]
+    fn first_offset(&self) -> usize {
+        (self.as_little_endian().0.trailing_zeros() as usize) >> 2
+    }
+
+    #[inline]
+    fn before(&self, rhs: &Self) -> bool {
+        (self.as_little_endian().0 & rhs.as_little_endian().0.wrapping_sub(1)) != 0
+    }
+
+    #[inline]
+    fn as_little_endian(&self) -> Self {
+        #[cfg(target_endian = "little")]
+        {
+            Self::new(self.0)
+        }
+        #[cfg(target_endian = "big")]
+        {
+            Self::new(self.0.swap_bytes())
+        }
+    }
+}
+
+pub fn combine_u16(lo: u16, hi: u16) -> u32 {
+    #[cfg(target_endian = "little")]
+    {
+        (lo as u32) | ((hi as u32) << 16)
+    }
+    #[cfg(target_endian = "big")]
+    {
+        (hi as u32) | ((lo as u32) << 16)
+    }
+}
+
+pub fn combine_u32(lo: u32, hi: u32) -> u64 {
+    #[cfg(target_endian = "little")]
+    {
+        (lo as u64) | ((hi as u64) << 32)
+    }
+    #[cfg(target_endian = "big")]
+    {
+        (hi as u64) | ((lo as u64) << 32)
+    }
+}

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -1,4 +1,4 @@
-mod bits;
+pub mod bits;
 mod traits;
 
 #[doc(hidden)]
@@ -39,13 +39,13 @@ cfg_if::cfg_if! {
     }
 }
 
-pub use self::traits::{Mask, Simd};
+pub use self::traits::{BitMask, Mask, Simd};
 // pick v512 simd
 // TODO: support avx512?
 mod v512;
 use self::v512::*;
 
-pub type u8x16 = Simd128i;
+pub type u8x16 = Simd128u;
 pub type u8x32 = Simd256u;
 pub type u8x64 = Simd512u;
 

--- a/src/util/simd/mod.rs
+++ b/src/util/simd/mod.rs
@@ -1,3 +1,4 @@
+mod bits;
 mod traits;
 
 #[doc(hidden)]

--- a/src/util/simd/neon.rs
+++ b/src/util/simd/neon.rs
@@ -98,13 +98,13 @@ pub(crate) const BIT_MASK_TAB: [u8; 16] = [
 pub struct Mask128(pub(crate) uint8x16_t);
 
 impl Mask for Mask128 {
-    type Bitmap = NeonBits;
+    type BitMask = NeonBits;
     type Element = u8;
 
     /// Convert Mask Vector 0x00-ff-ff to Bits 0b0000-1111-1111
     /// Reference: https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
     #[inline(always)]
-    fn bitmask(self) -> Self::Bitmap {
+    fn bitmask(self) -> Self::BitMask {
         unsafe {
             let v16 = vreinterpretq_u16_u8(self.0);
             let sr4 = vshrn_n_u16(v16, 4);

--- a/src/util/simd/neon.rs
+++ b/src/util/simd/neon.rs
@@ -73,7 +73,7 @@ impl Simd for Simd128i {
 
     #[inline(always)]
     fn splat(elem: i8) -> Self {
-        unsafe { Self(vdupq_n_s8(elem as i8)) }
+        unsafe { Self(vdupq_n_s8(elem)) }
     }
 
     // less or equal

--- a/src/util/simd/sse2.rs
+++ b/src/util/simd/sse2.rs
@@ -42,7 +42,8 @@ impl Simd for Simd128i {
 
     #[inline(always)]
     fn le(&self, rhs: &Self) -> Self::Mask {
-        unsafe { Mask128(_mm_cmpgt_epi8(rhs.0, self.0)) }
+        // self <= rhs equal as rhs >= self
+        rhs.gt(self) | rhs.eq(self)
     }
 
     #[inline(always)]

--- a/src/util/simd/sse2.rs
+++ b/src/util/simd/sse2.rs
@@ -61,11 +61,11 @@ impl_lanes!(Simd128u, 16);
 impl_lanes!(Mask128, 16);
 
 impl Mask for Mask128 {
-    type Bitmap = u16;
+    type BitMask = u16;
     type Element = u8;
 
     #[inline(always)]
-    fn bitmask(self) -> Self::Bitmap {
+    fn bitmask(self) -> Self::BitMask {
         unsafe { _mm_movemask_epi8(self.0) as u16 }
     }
 

--- a/src/util/simd/sse2.rs
+++ b/src/util/simd/sse2.rs
@@ -3,10 +3,8 @@ use std::{
     ops::{BitAnd, BitOr, BitOrAssign},
 };
 
-use crate::{
-    impl_lanes,
-    util::simd::{Mask, Simd},
-};
+use super::{Mask, Simd};
+use crate::impl_lanes;
 
 #[derive(Debug)]
 #[repr(transparent)]
@@ -19,6 +17,7 @@ pub struct Simd128u(__m128i);
 impl Simd for Simd128i {
     const LANES: usize = 16;
     type Mask = Mask128;
+    type Element = i8;
 
     #[inline(always)]
     unsafe fn loadu(ptr: *const u8) -> Self {
@@ -31,24 +30,24 @@ impl Simd for Simd128i {
     }
 
     #[inline(always)]
-    fn eq(&self, lhs: &Self) -> Self::Mask {
-        let eq = unsafe { _mm_cmpeq_epi8(self.0, lhs.0) };
+    fn eq(&self, rhs: &Self) -> Self::Mask {
+        let eq = unsafe { _mm_cmpeq_epi8(self.0, rhs.0) };
         Mask128(eq)
     }
 
     #[inline(always)]
-    fn splat(ch: u8) -> Self {
-        unsafe { Self(_mm_set1_epi8(ch as i8)) }
+    fn splat(elem: i8) -> Self {
+        unsafe { Self(_mm_set1_epi8(elem)) }
     }
 
     #[inline(always)]
-    fn le(&self, lhs: &Self) -> Self::Mask {
-        unsafe { Mask128(_mm_cmpgt_epi8(lhs.0, self.0)) }
+    fn le(&self, rhs: &Self) -> Self::Mask {
+        unsafe { Mask128(_mm_cmpgt_epi8(rhs.0, self.0)) }
     }
 
     #[inline(always)]
-    fn gt(&self, lhs: &Self) -> Self::Mask {
-        unsafe { Mask128(_mm_cmpgt_epi8(self.0, lhs.0)) }
+    fn gt(&self, rhs: &Self) -> Self::Mask {
+        unsafe { Mask128(_mm_cmpgt_epi8(self.0, rhs.0)) }
     }
 }
 
@@ -61,10 +60,11 @@ impl_lanes!(Simd128u, 16);
 impl_lanes!(Mask128, 16);
 
 impl Mask for Mask128 {
-    type BitMap = u16;
+    type Bitmap = u16;
+    type Element = u8;
 
     #[inline(always)]
-    fn bitmask(self) -> Self::BitMap {
+    fn bitmask(self) -> Self::Bitmap {
         unsafe { _mm_movemask_epi8(self.0) as u16 }
     }
 
@@ -103,6 +103,7 @@ impl BitOrAssign<Mask128> for Mask128 {
 impl Simd for Simd128u {
     const LANES: usize = 16;
     type Mask = Mask128;
+    type Element = u8;
 
     #[inline(always)]
     unsafe fn loadu(ptr: *const u8) -> Self {
@@ -115,8 +116,8 @@ impl Simd for Simd128u {
     }
 
     #[inline(always)]
-    fn eq(&self, lhs: &Self) -> Self::Mask {
-        let eq = unsafe { _mm_cmpeq_epi8(self.0, lhs.0) };
+    fn eq(&self, rhs: &Self) -> Self::Mask {
+        let eq = unsafe { _mm_cmpeq_epi8(self.0, rhs.0) };
         Mask128(eq)
     }
 
@@ -126,16 +127,16 @@ impl Simd for Simd128u {
     }
 
     #[inline(always)]
-    fn le(&self, lhs: &Self) -> Self::Mask {
+    fn le(&self, rhs: &Self) -> Self::Mask {
         unsafe {
-            let max = _mm_max_epu8(self.0, lhs.0);
-            let eq = _mm_cmpeq_epi8(max, lhs.0);
+            let max = _mm_max_epu8(self.0, rhs.0);
+            let eq = _mm_cmpeq_epi8(max, rhs.0);
             Mask128(eq)
         }
     }
 
     #[inline(always)]
-    fn gt(&self, _lhs: &Self) -> Self::Mask {
+    fn gt(&self, _rhs: &Self) -> Self::Mask {
         todo!()
     }
 }

--- a/src/util/simd/traits.rs
+++ b/src/util/simd/traits.rs
@@ -5,7 +5,7 @@ pub trait Simd: Sized {
     const LANES: usize;
 
     type Element;
-    type Mask;
+    type Mask: Mask;
 
     unsafe fn from_slice_unaligned_unchecked(slice: &[u8]) -> Self {
         debug_assert!(slice.len() >= Self::LANES);
@@ -35,7 +35,7 @@ pub trait Simd: Sized {
 /// Portbal SIMD mask traits
 pub trait Mask: Sized + BitOr<Self> + BitOrAssign + BitAnd<Self> {
     type Element;
-    type Bitmap;
+    type Bitmap: BitMask;
 
     fn bitmask(self) -> Self::Bitmap;
 
@@ -55,4 +55,10 @@ pub trait BitMask {
 
     /// convert bitmap as little endian
     fn as_little_endian(&self) -> Self;
+
+    /// whether all bits are zero.
+    fn all_zero(&self) -> bool;
+
+    /// clear high n bits.
+    fn clear_high_bits(&self, n: usize) -> Self;
 }

--- a/src/util/simd/traits.rs
+++ b/src/util/simd/traits.rs
@@ -4,6 +4,7 @@ use std::ops::{BitAnd, BitOr, BitOrAssign};
 pub trait Simd: Sized {
     const LANES: usize;
 
+    type Element;
     type Mask;
 
     unsafe fn from_slice_unaligned_unchecked(slice: &[u8]) -> Self {
@@ -20,19 +21,38 @@ pub trait Simd: Sized {
 
     unsafe fn storeu(&self, ptr: *mut u8);
 
-    fn eq(&self, lhs: &Self) -> Self::Mask;
+    fn eq(&self, rhs: &Self) -> Self::Mask;
 
-    fn splat(ch: u8) -> Self;
+    fn splat(elem: Self::Element) -> Self;
 
-    fn le(&self, lhs: &Self) -> Self::Mask;
+    /// greater than
+    fn gt(&self, rhs: &Self) -> Self::Mask;
 
-    fn gt(&self, lhs: &Self) -> Self::Mask;
+    /// less or equal
+    fn le(&self, rhs: &Self) -> Self::Mask;
 }
 
+/// Portbal SIMD mask traits
 pub trait Mask: Sized + BitOr<Self> + BitOrAssign + BitAnd<Self> {
-    type BitMap;
+    type Element;
+    type Bitmap;
 
-    fn bitmask(self) -> Self::BitMap;
+    fn bitmask(self) -> Self::Bitmap;
 
     fn splat(b: bool) -> Self;
+}
+
+/// Trait for Bitmap.
+pub trait BitMask {
+    /// Total bits in the bitmap.
+    const LEN: usize;
+
+    /// get the offset of the first `1` bit.
+    fn first_offset(&self) -> usize;
+
+    /// check if this bitmap is before the other bitmap.
+    fn before(&self, rhs: &Self) -> bool;
+
+    /// convert bitmap as little endian
+    fn as_little_endian(&self) -> Self;
 }

--- a/src/util/simd/traits.rs
+++ b/src/util/simd/traits.rs
@@ -35,25 +35,25 @@ pub trait Simd: Sized {
 /// Portbal SIMD mask traits
 pub trait Mask: Sized + BitOr<Self> + BitOrAssign + BitAnd<Self> {
     type Element;
-    type Bitmap: BitMask;
+    type BitMask: BitMask;
 
-    fn bitmask(self) -> Self::Bitmap;
+    fn bitmask(self) -> Self::BitMask;
 
     fn splat(b: bool) -> Self;
 }
 
-/// Trait for Bitmap.
+/// Trait for the bitmask of a vector Mask.
 pub trait BitMask {
-    /// Total bits in the bitmap.
+    /// Total bits in the bitmask.
     const LEN: usize;
 
     /// get the offset of the first `1` bit.
     fn first_offset(&self) -> usize;
 
-    /// check if this bitmap is before the other bitmap.
+    /// check if this bitmask is before the other bitmask.
     fn before(&self, rhs: &Self) -> bool;
 
-    /// convert bitmap as little endian
+    /// convert bitmask as little endian
     fn as_little_endian(&self) -> Self;
 
     /// whether all bits are zero.

--- a/src/util/simd/v128.rs
+++ b/src/util/simd/v128.rs
@@ -30,10 +30,10 @@ impl Simd for Simd128i {
         std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, Self::LANES);
     }
 
-    fn eq(&self, lhs: &Self) -> Self::Mask {
+    fn eq(&self, rhs: &Self) -> Self::Mask {
         let mut mask = [0u8; 16];
         for i in 0..Self::LANES {
-            mask[i] = if self.0[i] == lhs.0[i] { 1 } else { 0 };
+            mask[i] = if self.0[i] == rhs.0[i] { 1 } else { 0 };
         }
         Mask128(mask)
     }
@@ -42,18 +42,18 @@ impl Simd for Simd128i {
         Self([value as i8; Self::LANES])
     }
 
-    fn le(&self, lhs: &Self) -> Self::Mask {
+    fn le(&self, rhs: &Self) -> Self::Mask {
         let mut mask = [0u8; 16];
         for i in 0..Self::LANES {
-            mask[i] = if self.0[i] <= lhs.0[i] { 1 } else { 0 };
+            mask[i] = if self.0[i] <= rhs.0[i] { 1 } else { 0 };
         }
         Mask128(mask)
     }
 
-    fn gt(&self, lhs: &Self) -> Self::Mask {
+    fn gt(&self, rhs: &Self) -> Self::Mask {
         let mut mask = [0u8; 16];
         for i in 0..Self::LANES {
-            mask[i] = if self.0[i] > lhs.0[i] { 1 } else { 0 };
+            mask[i] = if self.0[i] > rhs.0[i] { 1 } else { 0 };
         }
         Mask128(mask)
     }
@@ -75,10 +75,10 @@ impl Simd for Simd128u {
         std::ptr::copy_nonoverlapping(data.as_ptr(), ptr, Self::LANES);
     }
 
-    fn eq(&self, lhs: &Self) -> Self::Mask {
+    fn eq(&self, rhs: &Self) -> Self::Mask {
         let mut mask = [0u8; 16];
         for i in 0..Self::LANES {
-            mask[i] = if self.0[i] == lhs.0[i] { 1 } else { 0 };
+            mask[i] = if self.0[i] == rhs.0[i] { 1 } else { 0 };
         }
         Mask128(mask)
     }
@@ -87,31 +87,42 @@ impl Simd for Simd128u {
         Self([value; Self::LANES])
     }
 
-    fn le(&self, lhs: &Self) -> Self::Mask {
+    fn le(&self, rhs: &Self) -> Self::Mask {
         let mut mask = [0u8; 16];
         for i in 0..Self::LANES {
-            mask[i] = if self.0[i] <= lhs.0[i] { 1 } else { 0 };
+            mask[i] = if self.0[i] <= rhs.0[i] { 1 } else { 0 };
         }
         Mask128(mask)
     }
 
-    fn gt(&self, lhs: &Self) -> Self::Mask {
+    fn gt(&self, rhs: &Self) -> Self::Mask {
         let mut mask = [0u8; 16];
         for i in 0..Self::LANES {
-            mask[i] = if self.0[i] > lhs.0[i] { 1 } else { 0 };
+            mask[i] = if self.0[i] > rhs.0[i] { 1 } else { 0 };
         }
         Mask128(mask)
     }
 }
 
 impl Mask for Mask128 {
-    type BitMap = u16;
+    type Bitmap = u16;
+    type Element = u8;
 
     fn bitmask(self) -> Self::BitMap {
-        self.0
-            .iter()
-            .enumerate()
-            .fold(0, |acc, (i, &b)| acc | ((b as u16) << i))
+        #[cfg(target_endian = "little")]
+        {
+            self.0
+                .iter()
+                .enumerate()
+                .fold(0, |acc, (i, &b)| acc | ((b as u16) << i))
+        }
+        #[cfg(target_endian = "big")]
+        {
+            self.0
+                .iter()
+                .enumerate()
+                .fold(0, |acc, (i, &b)| acc | ((b as u16) << (15 - i)))
+        }
     }
 
     fn splat(b: bool) -> Self {

--- a/src/util/simd/v128.rs
+++ b/src/util/simd/v128.rs
@@ -105,10 +105,10 @@ impl Simd for Simd128u {
 }
 
 impl Mask for Mask128 {
-    type Bitmap = u16;
+    type BitMask = u16;
     type Element = u8;
 
-    fn bitmask(self) -> Self::BitMap {
+    fn bitmask(self) -> Self::BitMask {
         #[cfg(target_endian = "little")]
         {
             self.0

--- a/src/util/simd/v256.rs
+++ b/src/util/simd/v256.rs
@@ -1,10 +1,7 @@
 use std::ops::{BitAnd, BitOr, BitOrAssign};
 
-use super::{Mask128, Simd128i, Simd128u};
-use crate::{
-    impl_lanes,
-    util::simd::{Mask, Simd},
-};
+use super::{bits::combine_u16, Mask, Mask128, Simd, Simd128i, Simd128u};
+use crate::impl_lanes;
 
 impl_lanes!(Simd256u, 32);
 
@@ -23,11 +20,11 @@ pub struct Simd256i((Simd128i, Simd128i));
 pub struct Mask256(pub(crate) (Mask128, Mask128));
 
 impl Mask for Mask256 {
-    type Bitmap = u32;
+    type BitMask = u32;
     type Element = u8;
 
     #[inline(always)]
-    fn bitmask(self) -> Self::Bitmap {
+    fn bitmask(self) -> Self::BitMask {
         cfg_if::cfg_if! {
             if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
                 use std::arch::aarch64::uint8x16_t;

--- a/src/util/simd/v512.rs
+++ b/src/util/simd/v512.rs
@@ -20,11 +20,11 @@ pub struct Simd512i((Simd256i, Simd256i));
 pub struct Mask512((Mask256, Mask256));
 
 impl Mask for Mask512 {
-    type Bitmap = u64;
+    type BitMask = u64;
     type Element = u8;
 
     #[inline(always)]
-    fn bitmask(self) -> Self::Bitmap {
+    fn bitmask(self) -> Self::BitMask {
         cfg_if::cfg_if! {
             if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
                 use std::arch::aarch64::uint8x16_t;

--- a/src/util/simd/v512.rs
+++ b/src/util/simd/v512.rs
@@ -31,10 +31,7 @@ impl Mask for Mask512 {
                 let (v0, v1) = self.0;
                 let (m0, m1) = v0.0;
                 let (m2, m3) = v1.0;
-                let b64 = unsafe {
-                    super::neon::to_bitmask64(m0.0, m1.0, m2.0, m3.0)
-                };
-                b64.into()
+                unsafe { super::neon::to_bitmask64(m0.0, m1.0, m2.0, m3.0) }
             } else {
                 combine_u32(self.0 .0.bitmask(), self.0 .1.bitmask())
             }

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -3,13 +3,17 @@ use std::{
     slice::{from_raw_parts, from_raw_parts_mut},
 };
 
+#[cfg(not(all(target_feature = "neon", target_arch = "aarch64")))]
+use crate::util::simd::u8x32;
+#[cfg(all(target_feature = "neon", target_arch = "aarch64"))]
+use crate::util::simd::{bits::NeonBits, u8x16};
 use crate::{
     error::ErrorCode::{
         self, ControlCharacterWhileParsingString, InvalidEscape, InvalidUnicodeCodePoint,
     },
     util::{
         arch::page_size,
-        simd::{bits::NeonBits, u8x16, BitMask, Mask, Simd},
+        simd::{BitMask, Mask, Simd},
         unicode::handle_unicode_codepoint_mut,
     },
 };
@@ -36,7 +40,7 @@ pub(crate) struct StringBlock<B: BitMask> {
 
 #[cfg(not(all(target_feature = "neon", target_arch = "aarch64")))]
 impl StringBlock<u32> {
-    const LANES: usize = 32;
+    pub(crate) const LANES: usize = 32;
 
     #[inline]
     pub fn new(v: &u8x32) -> Self {

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1243,12 +1243,11 @@ impl Value {
         let children = self.children_mut_unchecked::<(MaybeUninit<Value>, MaybeUninit<Value>)>();
         let len = children.len();
 
-        let end_key = unsafe { &mut (*children.as_mut_ptr().add(len)).0 };
-        let end_value = unsafe { &mut (*children.as_mut_ptr().add(len)).1 };
-        write_value(end_key, pair.0, self.shared());
-        write_value(end_value, pair.1, self.shared());
+        let end_pair = unsafe { &mut *children.as_mut_ptr().add(len) };
+        write_value(&mut end_pair.0, pair.0, self.shared());
+        write_value(&mut end_pair.1, pair.1, self.shared());
         self.add_len(1);
-        unsafe { &mut *(end_key as *mut _ as *mut Pair) }
+        unsafe { &mut *(end_pair as *mut _ as *mut Pair) }
     }
 
     fn add_len(&mut self, additional: isize) {

--- a/src/value/tls_buffer.rs
+++ b/src/value/tls_buffer.rs
@@ -8,7 +8,7 @@ use super::node::Value;
 // use const make thread local access faster
 
 thread_local! {
-   static NODE_BUF: std::cell::RefCell<Vec<ManuallyDrop<Value>>> = std::cell::RefCell::new(Vec::new());
+   static NODE_BUF: std::cell::RefCell<Vec<ManuallyDrop<Value>>> = const { std::cell::RefCell::new(Vec::new()) };
 }
 
 /// A thread-local buffer for temporary nodes. Avoid allocating temporary memory multiple times.


### PR DESCRIPTION
#### What type of PR is this?
Optimize and refactor
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
1. implement faster bitmask for NEON vector.[reference](https://community.arm.com/arm-community-blogs/b/infrastructure-solutions-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon)
2. refactor the codes of portable SIMD to support faster bitmap above.
3. deal with the different endianness when using bitmask for vector 

benchmark data:
deserialize_struct
```
twitter/sonic_rs::from_slice_unchecked
                        time:   [416.42 µs 417.61 µs 418.95 µs]
                        change: [-8.1303% -7.4773% -6.8652%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  9 (9.00%) high mild
  10 (10.00%) high severe
twitter/sonic_rs::from_slice
                        time:   [437.19 µs 438.17 µs 439.25 µs]
                        change: [-10.175% -9.5169% -8.8809%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

citm_catalog/sonic_rs::from_slice_unchecked
                        time:   [829.53 µs 830.77 µs 832.16 µs]
                        change: [-5.8317% -5.5663% -5.3073%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe
citm_catalog/sonic_rs::from_slice
                        time:   [850.73 µs 852.09 µs 853.61 µs]
                        change: [-5.6535% -5.3738% -5.1004%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe

canada/sonic_rs::from_slice_unchecked
                        time:   [3.1962 ms 3.2209 ms 3.2451 ms]
                        change: [-1.7136% -0.7248% +0.3155%] (p = 0.16 > 0.05)
                        No change in performance detected.
canada/sonic_rs::from_slice
                        time:   [3.2662 ms 3.2874 ms 3.3082 ms]
                        change: [-0.4885% +0.3860% +1.3043%] (p = 0.40 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild

```

serialize_value
```
twitter/sonic_rs::to_string
                        time:   [176.28 µs 177.38 µs 178.71 µs]
                        change: [-3.8439% -2.9233% -1.9506%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

citm_catalog/sonic_rs::to_string
                        time:   [345.75 µs 346.43 µs 347.25 µs]
                        change: [-1.9978% -1.5666% -1.1737%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  11 (11.00%) high severe

canada/sonic_rs::to_string
                        time:   [2.9357 ms 2.9412 ms 2.9478 ms]
                        change: [-0.8109% -0.1844% +0.3632%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
```

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
