### PR TITLE
fix: deserialize into Bytes bug and clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "sonic-rs"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arrayref",
  "bumpalo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonic-rs"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Volo Team <volo@cloudwego.io>"]
 edition = "2021"
 description = "Sonic-rs is a fast Rust JSON library based on SIMD"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ faststr = "0.2"
 json-benchmark = { git = "https://github.com/serde-rs/json-benchmark", default-features = false, features = ["all-files", "lib-serde"]}
 paste = "1.0"
 serde_bytes = "0.11"
+bytes = {version = "1.4", features = ["serde"]}
 chrono = { version = "0.4", features = ["serde"] }
 
 [profile.release]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "sonic-rs"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "arrayref",
  "bumpalo",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "sonic-rs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "arrayref",
  "bumpalo",

--- a/fuzz/fuzz_targets/from_slice.rs
+++ b/fuzz/fuzz_targets/from_slice.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![allow(clippy::mutable_key_type)]
 
 use libfuzzer_sys::fuzz_target;
 use serde_json::Value as JValue;

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,12 +6,7 @@ use core::{
     fmt::{self, Debug, Display},
     result,
 };
-use std::{
-    borrow::Cow,
-    error,
-    str::FromStr,
-    string::{String, ToString},
-};
+use std::{borrow::Cow, error, str::FromStr};
 
 use serde::{de, ser};
 use thiserror::Error as ErrorTrait;

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,5 +1,3 @@
-use std::convert::Into;
-
 use crate::{
     util::{private::Sealed, reborrow::DormantMutRef},
     value::{

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -298,7 +298,7 @@ impl<'a> LazyValue<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{get_unchecked, pointer, to_array_iter, value::JsonValueTrait};
+    use crate::{pointer, to_array_iter};
 
     const TEST_JSON: &str = r#"{
         "bool": true,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -69,8 +69,6 @@ macro_rules! check_visit {
     };
 }
 
-pub(crate) use perr;
-
 #[inline(always)]
 fn get_escaped_branchless_u64(prev_escaped: &mut u64, backslash: u64) -> u64 {
     const EVEN_BITS: u64 = 0x5555_5555_5555_5555;

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -472,7 +472,10 @@ impl<'de, 'a, R: Reader<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> 
                 Reference::Borrowed(b) => visitor.visit_borrowed_bytes(b),
                 Reference::Copied(b) => visitor.visit_bytes(b),
             },
-            b'[' => self.deserialize_seq(visitor),
+            b'[' => {
+                self.parser.read.backward(1);
+                self.deserialize_seq(visitor)
+            }
             _ => Err(self.peek_invalid_type(peek, &visitor)),
         };
 

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -6,11 +6,7 @@ use core::{
     fmt::{self, Display},
     num::FpCategory,
 };
-use std::{
-    io,
-    string::{String, ToString},
-    vec::Vec,
-};
+use std::io;
 
 use ::serde::ser::{self, Impossible, Serialize};
 

--- a/src/util/num/mod.rs
+++ b/src/util/num/mod.rs
@@ -5,8 +5,6 @@ mod lemire;
 mod slow;
 mod table;
 
-use std::result::Result;
-
 use self::{common::BiasedFp, float::RawFloat, table::POWER_OF_FIVE_128};
 use crate::{error::ErrorCode, util::arch::simd_str2int};
 

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, convert::Into, fmt::Debug, str::FromStr};
+use std::{borrow::Cow, fmt::Debug, str::FromStr};
 
 use faststr::FastStr;
 

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1727,10 +1727,7 @@ mod test {
     use std::path::Path;
 
     use super::*;
-    use crate::{
-        error::{make_error, Result},
-        from_slice, from_str, pointer,
-    };
+    use crate::{error::make_error, from_slice, from_str, pointer};
 
     #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
     struct ValueInStruct {

--- a/src/value/object.rs
+++ b/src/value/object.rs
@@ -935,7 +935,7 @@ impl<'de> serde::de::Deserialize<'de> for Object {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{from_str, object, to_string, Array, JsonValueMutTrait};
+    use crate::{from_str, to_string, Array, JsonValueMutTrait};
 
     #[test]
     fn test_object_serde() {

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -305,7 +305,6 @@ impl_container_eq!(Array Object);
 mod test {
     use faststr::FastStr;
 
-    use crate::{array, json};
     #[test]
     fn test_slice_eq() {
         assert_eq!(json!([1, 2, 3]), &[1, 2, 3]);

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -99,8 +99,6 @@ impl Serializer {
     }
 }
 
-use std::string::ToString;
-
 use crate::serde::tri;
 
 impl serde::Serializer for Serializer {


### PR DESCRIPTION
Fix the deserialize into `bytes:Bytes` bug and Clippy warnings