### PR TITLE
Re-export `Index`, `JsonInput` and `FastStr`

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -66,6 +66,7 @@ impl<'de> AsRef<[u8]> for JsonSlice<'de> {
     }
 }
 
+/// A trait for string/bytes-like types that can be parsed into JSON.
 pub trait JsonInput<'de>: Sealed {
     fn need_utf8_valid(&self) -> bool;
     fn to_json_slice(&self) -> JsonSlice<'de>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub mod serde;
 pub mod value;
 pub mod writer;
 
+// re-export FastStr
+pub use ::faststr::FastStr;
 // re-export the serde trait
 pub use ::serde::{Deserialize, Serialize};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ pub use ::serde::{Deserialize, Serialize};
 #[doc(inline)]
 pub use crate::error::{Error, Result};
 #[doc(inline)]
+pub use crate::index::Index;
+#[doc(inline)]
+pub use crate::input::JsonInput;
+#[doc(inline)]
 pub use crate::lazyvalue::{
     get, get_from_bytes, get_from_bytes_unchecked, get_from_faststr, get_from_faststr_unchecked,
     get_from_slice, get_from_slice_unchecked, get_from_str, get_from_str_unchecked, get_many,


### PR DESCRIPTION
Fixes #80.