### PR TITLE
chore: simplify  `Read` api and export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sonic-rs"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["Volo Team <volo@cloudwego.io>"]
 edition = "2021"
 description = "Sonic-rs is a fast Rust JSON library based on SIMD"

--- a/src/lazyvalue/get.rs
+++ b/src/lazyvalue/get.rs
@@ -8,7 +8,7 @@ use crate::{
     input::JsonInput,
     parser::{ParseStatus, Parser},
     pointer::PointerTree,
-    reader::{Reader, SliceRead},
+    reader::{Read, Reader},
     util::utf8::from_utf8,
 };
 
@@ -177,7 +177,7 @@ where
     Path::Item: Index,
 {
     let slice = json.to_u8_slice();
-    let reader = SliceRead::new(slice, false);
+    let reader = Read::new(slice, false);
     let mut parser = Parser::new(reader);
     let (sub, status) = parser.get_from_with_iter(path)?;
     LazyValue::new(json.from_subset(sub), status == ParseStatus::HasEscaped)
@@ -215,7 +215,7 @@ where
     Input: JsonInput<'de>,
 {
     let slice = json.to_u8_slice();
-    let reader = SliceRead::new(slice, false);
+    let reader = Read::new(slice, false);
     let mut parser = Parser::new(reader);
     parser.get_many(tree, false)
 }
@@ -386,7 +386,7 @@ where
     Path::Item: Index,
 {
     let slice = json.to_u8_slice();
-    let reader = SliceRead::new(slice, false);
+    let reader = Read::new(slice, false);
     let mut parser = Parser::new(reader);
     let (sub, status) = parser.get_from_with_iter_checked(path)?;
     let lv = LazyValue::new(json.from_subset(sub), status == ParseStatus::HasEscaped)?;
@@ -424,7 +424,7 @@ where
     Input: JsonInput<'de>,
 {
     let slice = json.to_u8_slice();
-    let reader = SliceRead::new(slice, false);
+    let reader = Read::new(slice, false);
     let mut parser = Parser::new(reader);
     let nodes = parser.get_many(tree, true)?;
 

--- a/src/lazyvalue/iterator.rs
+++ b/src/lazyvalue/iterator.rs
@@ -5,7 +5,7 @@ use crate::{
     input::{JsonInput, JsonSlice},
     lazyvalue::LazyValue,
     parser::{Parser, DEFAULT_KEY_BUF_CAPACITY},
-    reader::{Reader, SliceRead},
+    reader::{Read, Reader},
 };
 
 /// A lazied iterator for JSON object text. It will parse the JSON when iterating.
@@ -67,7 +67,7 @@ pub struct ArrayJsonIter<'de>(ArrayInner<'de>);
 
 struct ObjectInner<'de> {
     json: JsonSlice<'de>,
-    parser: Option<Parser<SliceRead<'static>>>,
+    parser: Option<Parser<Read<'static>>>,
     strbuf: Vec<u8>,
     first: bool,
     ending: bool,
@@ -76,7 +76,7 @@ struct ObjectInner<'de> {
 
 struct ArrayInner<'de> {
     json: JsonSlice<'de>,
-    parser: Option<Parser<SliceRead<'static>>>,
+    parser: Option<Parser<Read<'static>>>,
     first: bool,
     ending: bool,
     check: bool,
@@ -102,7 +102,7 @@ impl<'de> ObjectInner<'de> {
         if self.parser.is_none() {
             let slice = self.json.as_ref();
             let slice = unsafe { std::slice::from_raw_parts(slice.as_ptr(), slice.len()) };
-            let parser = Parser::new(SliceRead::new(slice, check));
+            let parser = Parser::new(Read::new(slice, check));
             // check invalid utf8
             match parser.read.check_utf8_final() {
                 Err(err) if check => {
@@ -152,7 +152,7 @@ impl<'de> ArrayInner<'de> {
         if self.parser.is_none() {
             let slice = self.json.as_ref();
             let slice = unsafe { std::slice::from_raw_parts(slice.as_ptr(), slice.len()) };
-            let parser = Parser::new(SliceRead::new(slice, check));
+            let parser = Parser::new(Read::new(slice, check));
             // check invalid utf8
             match parser.read.check_utf8_final() {
                 Err(err) if check => {

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -9,6 +9,8 @@ use std::{
 
 use faststr::FastStr;
 
+#[cfg(feature = "arbitrary_precision")]
+use crate::RawNumber;
 use crate::{
     from_str, get_unchecked, index::Index, input::JsonSlice, serde::Number, JsonType,
     JsonValueTrait, Result,

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -11,7 +11,7 @@ use faststr::FastStr;
 
 use crate::{
     from_str, get_unchecked, index::Index, input::JsonSlice, serde::Number, JsonType,
-    JsonValueTrait, RawNumber, Result,
+    JsonValueTrait, Result,
 };
 
 /// LazyValue wrappers a unparsed raw JSON text. It is borrowed from the origin JSON text.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub mod writer;
 pub use ::faststr::FastStr;
 // re-export the serde trait
 pub use ::serde::{Deserialize, Serialize};
+#[doc(inline)]
+pub use reader::Read;
 
 #[doc(inline)]
 pub use crate::error::{Error, Result};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, ops::Deref, ptr::NonNull};
 use crate::{
     error::invalid_utf8,
     util::{private::Sealed, utf8::from_utf8},
-    Result,
+    JsonInput, Result,
 };
 // support borrow for owned deserizlie or skip
 pub(crate) enum Reference<'b, 'c, T>
@@ -53,7 +53,9 @@ where
     }
 }
 
-/// Reader is a unified wrapper for inputs.
+/// Trait is used by the deserializer for iterating over input. And it is sealed and cannot be
+/// implemented for types outside of sonic_rs.
+
 #[doc(hidden)]
 pub trait Reader<'de>: Sealed {
     fn remain(&self) -> usize;
@@ -94,15 +96,20 @@ pub trait Reader<'de>: Sealed {
 }
 
 /// JSON input source that reads from a slice of bytes.
-pub(crate) struct SliceRead<'a> {
+pub struct Read<'a> {
     slice: &'a [u8],
     pub(crate) index: usize,
     // next invalid utf8 position, if not found, will be usize::MAX
     next_invalid_utf8: usize,
 }
 
-impl<'a> SliceRead<'a> {
-    pub fn new(slice: &'a [u8], need_validate: bool) -> Self {
+impl<'a> Read<'a> {
+    /// Make a `Read` from string/bytes-like JSON input.
+    pub fn from<I: JsonInput<'a>>(input: I) -> Self {
+        Self::new(input.to_u8_slice(), input.need_utf8_valid())
+    }
+
+    pub(crate) fn new(slice: &'a [u8], need_validate: bool) -> Self {
         // validate the utf-8 at first for slice
         let next_invalid_utf8 = if need_validate {
             match from_utf8(slice) {
@@ -121,7 +128,7 @@ impl<'a> SliceRead<'a> {
     }
 }
 
-impl<'a> Reader<'a> for SliceRead<'a> {
+impl<'a> Reader<'a> for Read<'a> {
     #[inline(always)]
     fn remain(&self) -> usize {
         self.slice.len() - self.index
@@ -332,14 +339,14 @@ mod test {
 
     fn test_peek() {
         let data = b"1234567890";
-        let mut reader = SliceRead::new(data, false);
+        let mut reader = Read::new(data, false);
         assert_eq!(reader.peek(), Some(b'1'));
         assert_eq!(reader.peek_n(4).unwrap(), &b"1234"[..]);
     }
 
     fn test_next() {
         let data = b"1234567890";
-        let mut reader = SliceRead::new(data, false);
+        let mut reader = Read::new(data, false);
         assert_eq!(reader.next(), Some(b'1'));
         assert_eq!(reader.peek(), Some(b'2'));
         assert_eq!(reader.next_n(4).unwrap(), &b"2345"[..]);
@@ -348,7 +355,7 @@ mod test {
 
     fn test_index() {
         let data = b"1234567890";
-        let mut reader = SliceRead::new(data, false);
+        let mut reader = Read::new(data, false);
         assert_eq!(reader.index(), 0);
 
         reader.next().unwrap();

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -15,7 +15,7 @@ use crate::{
         Result,
     },
     parser::{as_str, ParseStatus, Parser},
-    reader::{Reader, Reference, SliceRead},
+    reader::{Read, Reader, Reference},
     util::num::ParserNumber,
     value::node::Value,
 };
@@ -1162,7 +1162,7 @@ pub fn from_slice<'a, T>(json: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(SliceRead::new(json, true))
+    from_trait(Read::new(json, true))
 }
 
 /// Deserialize an instance of type `T` from bytes of JSON text.
@@ -1173,7 +1173,7 @@ pub unsafe fn from_slice_unchecked<'a, T>(json: &'a [u8]) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(SliceRead::new(json, false))
+    from_trait(Read::new(json, false))
 }
 
 /// Deserialize an instance of type `T` from a string of JSON text.
@@ -1181,5 +1181,5 @@ pub fn from_str<'a, T>(s: &'a str) -> Result<T>
 where
     T: de::Deserialize<'a>,
 {
-    from_trait(SliceRead::new(s.as_bytes(), false))
+    from_trait(Read::new(s.as_bytes(), false))
 }

--- a/src/util/private.rs
+++ b/src/util/private.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use faststr::FastStr;
 
 use crate::{
-    reader::{PaddedSliceRead, SliceRead},
+    reader::{PaddedSliceRead, Read},
     PointerNode,
 };
 
@@ -14,7 +14,7 @@ impl Sealed for std::string::String {}
 impl Sealed for FastStr {}
 impl Sealed for Bytes {}
 impl Sealed for u8 {}
-impl<'de> Sealed for SliceRead<'de> {}
+impl<'de> Sealed for Read<'de> {}
 impl<'de> Sealed for PaddedSliceRead<'de> {}
 impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
 impl<T> Sealed for [T] where T: Sized + Sealed {}

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -207,7 +207,7 @@ macro_rules! deserialize_numeric_key {
             V: Visitor<'de>,
         {
             let mut de =
-                crate::Deserializer::new(crate::reader::SliceRead::new(self.key.as_bytes(), false));
+                crate::Deserializer::new(crate::reader::Read::new(self.key.as_bytes(), false));
             match de.parser.read.peek() {
                 Some(b'0'..=b'9' | b'-') => {}
                 _ => return Err(Error::syntax(ErrorCode::ExpectedNumericKey, b"", 0)),


### PR DESCRIPTION
 we only use `Read` for all string/bytes like json inputs for user-friendliness.  In the future, we will use `IoRead` for IO inputs.
 
