### PR TITLE
feat: `get_many` returns `Vec<Rc<Result<..>>>`

### DIFF
--- a/examples/get_many.rs
+++ b/examples/get_many.rs
@@ -13,7 +13,7 @@ fn main() {
     let nodes = unsafe { sonic_rs::get_many_unchecked(json, &tree) };
 
     // the node order is as the order of `add_path`
-    for val in nodes.unwrap() {
+    for val in nodes {
         println!("{}", val.as_ref().as_ref().unwrap().as_raw_str());
         // 123
         // "found"

--- a/examples/get_many.rs
+++ b/examples/get_many.rs
@@ -14,7 +14,7 @@ fn main() {
 
     // the node order is as the order of `add_path`
     for val in nodes.unwrap() {
-        println!("{}", val.as_raw_str());
+        println!("{}", val.as_ref().as_ref().unwrap().as_raw_str());
         // 123
         // "found"
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2110,14 +2110,16 @@ where
         &mut self,
         tree: &PointerTree,
         is_safe: bool,
-    ) -> Result<Vec<Rc<Result<LazyValue<'de>>>>> {
+    ) -> Vec<Rc<Result<LazyValue<'de>>>> {
         let mut strbuf = Vec::with_capacity(DEFAULT_KEY_BUF_CAPACITY);
         let mut remain = tree.size();
         let mut out = Vec::with_capacity(tree.size());
         out.resize(tree.size(), Rc::new(Ok(LazyValue::default())));
         let cur = &tree.root;
-        self.get_many_rec(cur, &mut out, &mut strbuf, &mut remain, is_safe)?;
-        Ok(out)
+        if let Err(err) = self.get_many_rec(cur, &mut out, &mut strbuf, &mut remain, is_safe) {
+            out.fill(Rc::new(Err(err)));
+        }
+        out
     }
 
     #[inline]


### PR DESCRIPTION
I try to make `get_many` return `Vec<Result<LazyValue>>` instead of `Result<Vector<LazyValue>>`. I think the purpose is to generate separate errors for each query path rather than one overall error.

Now everything seems ok, but there are still some problems and I'm hoping for some suggestions:
1. It's hard to return `Vec<Result<LazyValue>>` directly. As my code shows, a solution is replacing every element in `out` with the same error.
    1. `get_many` has to validate utf8 input. This is a validation for the whole input.
    2. We should handle the result of top level `self.get_many_rec` call in `get_many`. 
    https://github.com/cloudwego/sonic-rs/blob/99b37cd1ff4dfdf5b9ee8b45c91f1403f7c0257a/src/parser.rs#L2119
  
2. I wrap `Result<LazyValue<'_>>` in `Rc`:
    **Motivation**: We need to clone the LazyValue for all possible orders. However, `Result` is not clonable since `Error` is not clonable. Implement `Clone` for `Error` is either impossible, because the inner `std::io::Error` is not clonable.
    https://github.com/cloudwego/sonic-rs/blob/99b37cd1ff4dfdf5b9ee8b45c91f1403f7c0257a/src/parser.rs#L1859
    **Pros**: Performance is optimized by avoiding `lv.clone()`
    **Cons**: It's hard to use the result. As the example shows, we have to write `many[0].as_ref().as_ref().unwrap().as_raw_str()` compared to the original `many[0].as_raw_str()`

Any suggestion? 