### PR TITLE
fix: Fix compilation of fallback backend and minor issues

### DIFF
--- a/sonic-simd/src/v128.rs
+++ b/sonic-simd/src/v128.rs
@@ -1,5 +1,7 @@
 use std::ops::{BitAnd, BitOr, BitOrAssign};
 
+use super::{Mask, Simd};
+
 #[derive(Debug)]
 pub struct Simd128i([i8; 16]);
 

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1330,7 +1330,7 @@ where
     // check JSON size, because the design of `sonic_rs::Value`, parsing JSON larger than 4 GB is
     // not supported
     let len = read.as_u8_slice().len();
-    if len >= (1 << 32) {
+    if len >= (u32::MAX / 2) as _ {
         return Err(crate::error::make_error(format!(
             "Only support JSON less than 4 GB, the input JSON is too large here, len is {len}"
         )));

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1330,7 +1330,7 @@ where
     // check JSON size, because the design of `sonic_rs::Value`, parsing JSON larger than 4 GB is
     // not supported
     let len = read.as_u8_slice().len();
-    if len >= (u32::MAX / 2) as _ {
+    if len > u32::MAX as _ {
         return Err(crate::error::make_error(format!(
             "Only support JSON less than 4 GB, the input JSON is too large here, len is {len}"
         )));

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1492,7 +1492,7 @@ impl<'a> DocumentVisitor<'a> {
 #[repr(C)]
 struct MetaNode {
     shared: *const Shared,
-    canary: usize,
+    canary: u64,
 }
 
 impl MetaNode {
@@ -1500,7 +1500,7 @@ impl MetaNode {
         let canary = b"SONICRS\0";
         MetaNode {
             shared,
-            canary: unsafe { transmute::<&[u8; 8], usize>(canary) },
+            canary: unsafe { transmute::<[u8; 8], u64>(*canary) },
         }
     }
 }


### PR DESCRIPTION
#### What type of PR is this?

fix: Fix compilation on 32-bit architectures

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->

`sonic-rs` in its current form fails to compile for 32-bit architectures, such as `armv7-unknown-linux-musleabihf`. While niche, I still thing it's a worthwhile thing to support.

It also fixes some logic bugs uncovered by compiling it to 32-bit.

Bug 1: Documenting a maximum of 2GB and then restricting to 1 << 32 (which evaluates to 4GB instead)
Bug 2: Transmuting a `&[u8; 8]` into a `u64` which won't contain a copy of the data and instead just the pointer, technically producing a dangling pointer that is never dereferenced

---

Please let me know if I should add a GitHub Actions workflow that executes `cross test --target=armv7-unknown-linux-musleabihf`.
