### PR TITLE
perf: use hashmap in owned object to optimize search performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version       = "0.4.0-rc4"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ahash        = "0.8"
 bumpalo      = "3.13"
 bytes        = "1.9"
 cfg-if       = "1.0"

--- a/benchmarks/benches/value_operator.rs
+++ b/benchmarks/benches/value_operator.rs
@@ -177,10 +177,12 @@ fn bench_object_insert(c: &mut Criterion) {
         b.iter_batched(
             || (),
             |_| {
-                let mut val = sonic_rs::Object::new();
+                let mut val = sonic_rs::Object::with_capacity(100);
                 for i in 0..100 {
                     let mut obj = sonic_rs::json!({"a":{"b":{"c":{"d":{}}}}});
-                    for j in 0..100 {
+                    *obj["a"]["b"]["c"]["d"].as_object_mut().unwrap() =
+                        sonic_rs::Object::with_capacity(1000);
+                    for j in 0..1000 {
                         obj["a"]["b"]["c"]["d"]
                             .as_object_mut()
                             .unwrap()
@@ -200,7 +202,7 @@ fn bench_object_insert(c: &mut Criterion) {
                 let mut val = serde_json::Map::new();
                 for i in 0..100 {
                     let mut obj = serde_json::json!({"a":{"b":{"c":{"d":{}}}}});
-                    for j in 0..100 {
+                    for j in 0..1000 {
                         obj["a"]["b"]["c"]["d"]
                             .as_object_mut()
                             .unwrap()

--- a/src/index.rs
+++ b/src/index.rs
@@ -170,7 +170,7 @@ macro_rules! impl_str_index {
                     if !v.is_object() {
                         return None;
                     }
-                    v.get_key_mut(*self).map(|v| v.0)
+                    v.get_key_mut(*self)
                 }
 
                 #[inline]
@@ -184,11 +184,11 @@ macro_rules! impl_str_index {
                     obj.as_object_mut()
                         .expect(&format!("cannot access key in non-object value {:?}", typ))
                         .0
-                        .get_key_mut(*self).map_or_else(|| {
+                        .get_key_mut(*self).unwrap_or_else(|| {
                             let o =  unsafe { dormant_obj.reborrow() };
-                            let inserted = o.append_pair((Into::<Value>::into((*self)), Value::new_null()));
-                            &mut inserted.1
-                        }, |v| v.0)
+                            let inserted = o.insert(&self, Value::new_null());
+                            inserted
+                        })
                 }
 
                 #[inline]

--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -272,19 +272,11 @@ impl<'a> JsonValueTrait for LazyValue<'a> {
     }
 
     fn as_number(&self) -> Option<Number> {
-        if let Ok(num) = from_str(self.as_raw_str()) {
-            Some(num)
-        } else {
-            None
-        }
+        from_str(self.as_raw_str()).ok()
     }
 
     fn as_raw_number(&self) -> Option<RawNumber> {
-        if let Ok(num) = from_str(self.as_raw_str()) {
-            Some(num)
-        } else {
-            None
-        }
+        from_str(self.as_raw_str()).ok()
     }
 
     fn as_str(&self) -> Option<&str> {

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -563,10 +563,10 @@ mod test {
         let x: Value = map.iter().collect();
         assert_eq!(x, json!({"sonic_rs": 40, "json": 2}));
 
-        let v = std::iter::repeat(6).take(3);
+        let v = std::iter::repeat_n(6, 3);
         let x1: Vec<_> = v.collect();
         dbg!(x1);
-        let v = std::iter::repeat(6).take(3);
+        let v = std::iter::repeat_n(6, 3);
         let x: Value = v.collect();
         assert_eq!(x, json!([6, 6, 6]));
 

--- a/src/value/macros.rs
+++ b/src/value/macros.rs
@@ -226,8 +226,7 @@ macro_rules! json_internal {
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
         let key: &str = ($($key)+).as_ref();
-        let pair = ($crate::Value::copy_str(key), $value);
-        let _ = $object.append_pair(pair);
+        let _ = $object.insert(key, $value);
         json_internal!(@object $object () ($($rest)*) ($($rest)*));
     };
 
@@ -239,8 +238,7 @@ macro_rules! json_internal {
     // Insert the last entry without trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr)) => {
         let key: &str = ($($key)+).as_ref();
-        let pair = ($crate::Value::copy_str(key), $value);
-        let _ = $object.append_pair(pair);
+        let _ = $object.insert(key, $value);
     };
 
     // Next value is `null`.

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -10,6 +10,7 @@ use std::{
     sync::Arc,
 };
 
+use ahash::AHashMap;
 use bumpalo::Bump;
 use faststr::FastStr;
 use ref_cast::RefCast;
@@ -79,27 +80,27 @@ pub struct Value {
 //  - Owned Node : mutable
 //  - Shared Node: in SharedDom, not mutable
 //
-// | Kind        | 3 bits | 5 bits |       24 bits     |     ---->  32 bits ---->       |   32 bits   |  32 bits  |       limit          |
-// |-------------|-----------------|-------------------|--------------------------------|-------------------------|----------------------|
-// |  Null       |   0    |   0    |                                                    +                         |                      |
-// |  True       |   0    |   1    |                                                    +                         |                      |
-// |  False      |   0    |   2    |                                                    +                         |                      |
-// |  I64        |   0    |   3    |                                                    +           i64           |                      |
-// |  U64        |   0    |   4    |                                                    +           u64           |                      |
-// |  F64        |   0    |   5    |                                                    +           f64           |                      |
-// | empty arr   |   0    |   6    |                                                                              |
-// | empty obj   |   0    |   7    |                                                                              |
-// | static str  |   0    |   8    |                   |           string length        +         *const u8       | excced will fallback |
-// |  faststr    |   1    |   0    |                                                    +       Box<FastStr>      |                      |
-// |rawnum_fastst|   1    |   1    |                                                    +       Box<FastStr>      |                      |
-// |  arr_mut    |   1    |   2    |                                                    +       Arc<Vec<Node>>    |                      |
-// |  obj_mut    |   1    |   3    |                                                    +       Arc<Vec<Pair>>    |                      |
-// |  str_node   |   2    |        node idx            |           string length        +         *const u8       |    max len 2^32      |
-// | raw_num_node|   3    |        node idx            |           string length        +         *const u8       |    max len 2^32      |
-// |  arr_node   |   4    |        node idx            |           array length         +         *const Node     |    max len 2^32      |
-// |  obj_node   |   5    |        node idx            |           object length        +         *const Pair     |    max len 2^32      |
-// |str_esc_raw  |   6    |   *const RawStrHeader (in SharedDom, MUST aligned 8)        +         *const u8       |                      |
-// | root_node   |   7    |      *const ShardDom (from Arc, MUST aligned 8)             +     *const Node (head)  |                      |
+// | Kind        | 3 bits | 5 bits |       24 bits     |     ---->  32 bits ---->       |    32 bits    |    32 bits    |       limit          |
+// |-------------|-----------------|-------------------|--------------------------------|-------------------------------|----------------------|
+// |  Null       |   0    |   0    |                                                    +                               |                      |
+// |  True       |   0    |   1    |                                                    +                               |                      |
+// |  False      |   0    |   2    |                                                    +                               |                      |
+// |  I64        |   0    |   3    |                                                    +             i64               |                      |
+// |  U64        |   0    |   4    |                                                    +             u64               |                      |
+// |  F64        |   0    |   5    |                                                    +             f64               |                      |
+// | empty arr   |   0    |   6    |                                                                                    |
+// | empty obj   |   0    |   7    |                                                                                    |
+// | static str  |   0    |   8    |                   |           string length        +          *const u8            | excced will fallback |
+// |  faststr    |   1    |   0    |                                                    +         Box<FastStr>          |                      |
+// |rawnum_fastst|   1    |   1    |                                                    +         Box<FastStr>          |                      |
+// |  arr_mut    |   1    |   2    |                                                    +        Arc<Vec<Node>>         |                      |
+// |  obj_mut    |   1    |   3    |                                                    + Arc<AHashMap<FastStr, Value>> |                      |
+// |  str_node   |   2    |        node idx            |           string length        +          *const u8            |    max len 2^32      |
+// | raw_num_node|   3    |        node idx            |           string length        +          *const u8            |    max len 2^32      |
+// |  arr_node   |   4    |        node idx            |           array length         +          *const Node          |    max len 2^32      |
+// |  obj_node   |   5    |        node idx            |           object length        +          *const Pair          |    max len 2^32      |
+// |str_esc_raw  |   6    |   *const RawStrHeader (in SharedDom, MUST aligned 8)        +          *const u8            |                      |
+// | root_node   |   7    |      *const ShardDom (from Arc, MUST aligned 8)             +      *const Node (head)       |                      |
 //
 // NB: we will check the JSON length when parsing, if JSON is >= 4GB, will return a error, so we will not check the limits when parsing or using dom.
 #[allow(clippy::box_collection)]
@@ -117,7 +118,7 @@ pub(crate) union Data {
     pub(crate) root: NonNull<Value>,
 
     pub(crate) str_own: ManuallyDrop<Box<FastStr>>,
-    pub(crate) obj_own: ManuallyDrop<Arc<Vec<Pair>>>,
+    pub(crate) obj_own: ManuallyDrop<Arc<AHashMap<FastStr, Value>>>,
     pub(crate) arr_own: ManuallyDrop<Arc<Vec<Value>>>,
 
     pub(crate) parent: u64,
@@ -427,7 +428,7 @@ enum ValueDetail<'a> {
     FastStr(&'a FastStr),
     RawNumFasStr(&'a FastStr),
     Array(&'a Arc<Vec<Value>>),
-    Object(&'a Arc<Vec<Pair>>),
+    Object(&'a Arc<AHashMap<FastStr, Value>>),
     Root(NodeInDom<'a>),
     NodeInDom(NodeInDom<'a>),
     EmptyArray,
@@ -474,13 +475,21 @@ pub enum ValueRefInner<'a> {
     RawNum(&'a str),
     Array(&'a [Value]),
     Object(&'a [Pair]),
+    ObjectOwned(&'a Arc<AHashMap<FastStr, Value>>),
     EmptyArray,
     EmptyObject,
 }
 
 impl<'a> From<&'a [Pair]> for Value {
     fn from(value: &'a [Pair]) -> Self {
-        let newd = value.to_vec();
+        let mut newd = AHashMap::with_capacity(value.len());
+
+        for (k, v) in value {
+            if let Some(k) = k.as_str() {
+                newd.insert(FastStr::new(k), v.clone());
+            }
+        }
+
         Self {
             meta: Meta::new(Meta::OBJ_MUT),
             data: Data {
@@ -518,7 +527,7 @@ pub(crate) enum ValueMut<'a> {
     Str,
     RawNum,
     Array(&'a mut Vec<Value>),
-    Object(&'a mut Vec<Pair>),
+    Object(&'a mut AHashMap<FastStr, Value>),
 }
 
 impl Value {
@@ -609,7 +618,7 @@ impl Value {
             ValueDetail::FastStr(s) => ValueRefInner::Str(s.as_str()),
             ValueDetail::RawNumFasStr(s) => ValueRefInner::RawNum(s.as_str()),
             ValueDetail::Array(a) => ValueRefInner::Array(a),
-            ValueDetail::Object(o) => ValueRefInner::Object(o),
+            ValueDetail::Object(o) => ValueRefInner::ObjectOwned(o),
             ValueDetail::Root(n) | ValueDetail::NodeInDom(n) => n.get_inner(),
             ValueDetail::EmptyArray => ValueRefInner::EmptyArray,
             ValueDetail::EmptyObject => ValueRefInner::EmptyObject,
@@ -693,8 +702,8 @@ impl From<Arc<Vec<Value>>> for Value {
     }
 }
 
-impl From<Arc<Vec<Pair>>> for Value {
-    fn from(value: Arc<Vec<Pair>>) -> Self {
+impl From<Arc<AHashMap<FastStr, Value>>> for Value {
+    fn from(value: Arc<AHashMap<FastStr, Value>>) -> Self {
         Self {
             meta: Meta::new(Meta::OBJ_MUT),
             data: Data {
@@ -770,7 +779,7 @@ impl super::value_trait::JsonValueTrait for Value {
             ValueRefInner::Number(_) => JsonType::Number,
             ValueRefInner::Str(_) | ValueRefInner::RawStr(_) => JsonType::String,
             ValueRefInner::Array(_) => JsonType::Array,
-            ValueRefInner::Object(_) => JsonType::Object,
+            ValueRefInner::Object(_) | ValueRefInner::ObjectOwned(_) => JsonType::Object,
             ValueRefInner::RawNum(_) => JsonType::Number,
             ValueRefInner::EmptyArray => JsonType::Array,
             ValueRefInner::EmptyObject => JsonType::Object,
@@ -963,9 +972,9 @@ impl Value {
             ValueRefInner::Array(_) | ValueRefInner::EmptyArray => {
                 ValueRef::Array(self.as_array().unwrap())
             }
-            ValueRefInner::Object(_) | ValueRefInner::EmptyObject => {
-                ValueRef::Object(self.as_object().unwrap())
-            }
+            ValueRefInner::Object(_)
+            | ValueRefInner::EmptyObject
+            | ValueRefInner::ObjectOwned(_) => ValueRef::Object(self.as_object().unwrap()),
             ValueRefInner::RawNum(raw) => {
                 crate::from_str(raw).map_or(ValueRef::Null, ValueRef::Number)
             }
@@ -1197,7 +1206,7 @@ impl Value {
 
     #[doc(hidden)]
     pub fn new_object_with(capacity: usize) -> Self {
-        let obj_own = ManuallyDrop::new(Arc::new(Vec::with_capacity(capacity)));
+        let obj_own = ManuallyDrop::new(Arc::new(AHashMap::with_capacity(capacity)));
         Value {
             meta: Meta::new(Meta::OBJ_MUT),
             data: Data { obj_own },
@@ -1231,39 +1240,27 @@ impl Value {
 
     pub(crate) fn get_key_value(&self, key: &str) -> Option<(&str, &Self)> {
         debug_assert!(self.is_object());
-        if let ValueRefInner::Object(kv) = self.as_ref2() {
+        let ref_inner = self.as_ref2();
+        if let ValueRefInner::Object(kv) = ref_inner {
             for (k, v) in kv {
                 let k = k.as_str().expect("key is not string");
                 if k == key {
                     return Some((k, v));
                 }
             }
-        }
-        None
-    }
-
-    #[inline]
-    pub(crate) fn get_key_offset(&self, key: &str) -> Option<usize> {
-        debug_assert!(self.is_object());
-        if let ValueRefInner::Object(kv) = self.as_ref2() {
-            for (i, pair) in kv.iter().enumerate() {
-                debug_assert!(pair.0.is_str());
-                if pair.0.equal_str(key) {
-                    return Some(i);
-                }
+        } else if let ValueRefInner::ObjectOwned(kv) = ref_inner {
+            if let Some((k, v)) = kv.get_key_value(key) {
+                return Some((k.as_str(), v));
             }
         }
         None
     }
 
     #[inline]
-    pub(crate) fn get_key_mut(&mut self, key: &str) -> Option<(&mut Self, usize)> {
+    pub(crate) fn get_key_mut(&mut self, key: &str) -> Option<&mut Self> {
         if let ValueMut::Object(kv) = self.as_mut() {
-            for (i, (k, v)) in kv.iter_mut().enumerate() {
-                debug_assert!(k.is_str());
-                if k.equal_str(key) {
-                    return Some((v, i));
-                }
+            if let Some(v) = kv.get_mut(key) {
+                return Some(v);
             }
         }
         None
@@ -1313,22 +1310,11 @@ impl Value {
     }
 
     #[inline]
-    pub(crate) fn remove_pair_index(&mut self, index: usize) -> (Value, Value) {
-        debug_assert!(self.is_object());
-        match self.as_mut() {
-            ValueMut::Object(obj) => obj.remove(index),
-            _ => unreachable!("value is not object"),
-        }
-    }
-
-    #[inline]
     pub(crate) fn remove_key(&mut self, k: &str) -> Option<Value> {
         debug_assert!(self.is_object());
-        if let Some(i) = self.get_key_offset(k) {
-            let (_, val) = self.remove_pair_index(i);
-            Some(val)
-        } else {
-            None
+        match self.as_mut() {
+            ValueMut::Object(obj) => obj.remove(k),
+            _ => unreachable!("value is not object"),
         }
     }
 
@@ -1380,13 +1366,12 @@ impl Value {
 
     #[doc(hidden)]
     #[inline]
-    pub fn append_pair(&mut self, pair: Pair) -> &mut Pair {
+    pub fn insert(&mut self, key: &str, val: Value) -> &mut Value {
         debug_assert!(self.is_object());
         match self.as_mut() {
             ValueMut::Object(obj) => {
-                obj.push(pair);
-                let len = obj.len();
-                &mut obj[len - 1]
+                obj.insert(FastStr::new(key), val);
+                obj.get_mut(key).unwrap()
             }
             _ => unreachable!("value is not object"),
         }
@@ -1397,15 +1382,6 @@ impl Value {
         debug_assert!(self.is_array());
         match self.as_mut() {
             ValueMut::Array(arr) => arr.pop(),
-            _ => unreachable!("value is not object"),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn pop_pair(&mut self) -> Option<Pair> {
-        debug_assert!(self.is_object());
-        match self.as_mut() {
-            ValueMut::Object(obj) => obj.pop(),
             _ => unreachable!("value is not object"),
         }
     }
@@ -1790,6 +1766,26 @@ impl Serialize for Value {
                         } else {
                             tri!(map.serialize_key(k.as_str().unwrap()));
                         }
+                        tri!(map.serialize_value(v));
+                    }
+                    map.end()
+                }
+            }
+            ValueRefInner::ObjectOwned(o) => {
+                #[cfg(feature = "sort_keys")]
+                {
+                    let mut map = tri!(serializer.serialize_map(Some(o.len())));
+                    for (k, v) in o.iter() {
+                        tri!(map.serialize_key(k.as_str()));
+                        tri!(map.serialize_value(v));
+                    }
+                    map.end()
+                }
+                #[cfg(not(feature = "sort_keys"))]
+                {
+                    let mut map = tri!(serializer.serialize_map(Some(o.len())));
+                    for (k, v) in o.iter() {
+                        tri!(map.serialize_key(k.as_str()));
                         tri!(map.serialize_value(v));
                     }
                     map.end()

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1162,14 +1162,6 @@ impl Value {
         }
     }
 
-    pub(crate) fn as_pair_slice(&self) -> Option<&[Pair]> {
-        match self.as_ref2() {
-            ValueRefInner::Object(s) => Some(s),
-            ValueRefInner::EmptyObject => Some(&[]),
-            _ => None,
-        }
-    }
-
     pub(crate) fn as_obj_len(&self) -> usize {
         match self.as_ref2() {
             ValueRefInner::Object(s) => s.len(),
@@ -1273,12 +1265,6 @@ impl Value {
             }
         }
         None
-    }
-
-    #[inline]
-    fn equal_str(&self, val: &str) -> bool {
-        debug_assert!(self.is_str());
-        self.as_str().expect("value is not string") == val
     }
 
     #[inline]

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1170,6 +1170,15 @@ impl Value {
         }
     }
 
+    pub(crate) fn as_obj_len(&self) -> usize {
+        match self.as_ref2() {
+            ValueRefInner::Object(s) => s.len(),
+            ValueRefInner::EmptyObject => 0,
+            ValueRefInner::ObjectOwned(s) => s.len(),
+            _ => unreachable!("value is not object"),
+        }
+    }
+
     #[doc(hidden)]
     #[inline]
     pub fn copy_str(val: &str) -> Self {

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1240,7 +1240,10 @@ impl Value {
     }
 
     #[doc(hidden)]
-    pub fn new_object_with(capacity: usize) -> Self {
+    pub fn new_object_with(
+        #[cfg(not(feature = "sort_keys"))] capacity: usize,
+        #[cfg(feature = "sort_keys")] _: usize,
+    ) -> Self {
         let obj_own = ManuallyDrop::new(Arc::new(
             #[cfg(not(feature = "sort_keys"))]
             AHashMap::with_capacity(capacity),

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -83,27 +83,27 @@ pub struct Value {
 //  - Owned Node : mutable
 //  - Shared Node: in SharedDom, not mutable
 //
-// | Kind        | 3 bits | 5 bits |       24 bits     |     ---->  32 bits ---->       |    32 bits    |    32 bits    |       limit          |
-// |-------------|-----------------|-------------------|--------------------------------|-------------------------------|----------------------|
-// |  Null       |   0    |   0    |                                                    +                               |                      |
-// |  True       |   0    |   1    |                                                    +                               |                      |
-// |  False      |   0    |   2    |                                                    +                               |                      |
-// |  I64        |   0    |   3    |                                                    +             i64               |                      |
-// |  U64        |   0    |   4    |                                                    +             u64               |                      |
-// |  F64        |   0    |   5    |                                                    +             f64               |                      |
-// | empty arr   |   0    |   6    |                                                                                    |
-// | empty obj   |   0    |   7    |                                                                                    |
-// | static str  |   0    |   8    |                   |           string length        +          *const u8            | excced will fallback |
-// |  faststr    |   1    |   0    |                                                    +         Box<FastStr>          |                      |
-// |rawnum_fastst|   1    |   1    |                                                    +         Box<FastStr>          |                      |
-// |  arr_mut    |   1    |   2    |                                                    +        Arc<Vec<Node>>         |                      |
-// |  obj_mut    |   1    |   3    |                                                    + Arc<AHashMap<FastStr, Value>> |                      |
-// |  str_node   |   2    |        node idx            |           string length        +          *const u8            |    max len 2^32      |
-// | raw_num_node|   3    |        node idx            |           string length        +          *const u8            |    max len 2^32      |
-// |  arr_node   |   4    |        node idx            |           array length         +          *const Node          |    max len 2^32      |
-// |  obj_node   |   5    |        node idx            |           object length        +          *const Pair          |    max len 2^32      |
-// |str_esc_raw  |   6    |   *const RawStrHeader (in SharedDom, MUST aligned 8)        +          *const u8            |                      |
-// | root_node   |   7    |      *const ShardDom (from Arc, MUST aligned 8)             +      *const Node (head)       |                      |
+// |  Kind        | 3 bits | 5 bits |       24 bits     |     ---->  32 bits ---->       |    32 bits    |    32 bits    |       limit          |
+// |--------------|-----------------|-------------------|--------------------------------|-------------------------------|----------------------|
+// |   Null       |   0    |   0    |                                                    +                               |                      |
+// |   True       |   0    |   1    |                                                    +                               |                      |
+// |   False      |   0    |   2    |                                                    +                               |                      |
+// |   I64        |   0    |   3    |                                                    +             i64               |                      |
+// |   U64        |   0    |   4    |                                                    +             u64               |                      |
+// |   F64        |   0    |   5    |                                                    +             f64               |                      |
+// |  empty arr   |   0    |   6    |                                                                                    |
+// |  empty obj   |   0    |   7    |                                                                                    |
+// |  static str  |   0    |   8    |                   |           string length        +          *const u8            | excced will fallback |
+// |   faststr    |   1    |   0    |                                                    +         Box<FastStr>          |                      |
+// |rawnum_faststr|   1    |   1    |                                                    +         Box<FastStr>          |                      |
+// |   arr_mut    |   1    |   2    |                                                    +        Arc<Vec<Node>>         |                      |
+// |   obj_mut    |   1    |   3    |                                                    + Arc<AHashMap<FastStr, Value>> |                      |
+// |   str_node   |   2    |        node idx            |           string length        +          *const u8            |    max len 2^32      |
+// | raw_num_node |   3    |        node idx            |           string length        +          *const u8            |    max len 2^32      |
+// |   arr_node   |   4    |        node idx            |           array length         +          *const Node          |    max len 2^32      |
+// |   obj_node   |   5    |        node idx            |           object length        +          *const Pair          |    max len 2^32      |
+// | str_esc_raw  |   6    |   *const RawStrHeader (in SharedDom, MUST aligned 8)        +          *const u8            |                      |
+// |  root_node   |   7    |      *const ShardDom (from Arc, MUST aligned 8)             +      *const Node (head)       |                      |
 //
 // NB: we will check the JSON length when parsing, if JSON is >= 4GB, will return a error, so we will not check the limits when parsing or using dom.
 #[allow(clippy::box_collection)]

--- a/src/value/object.rs
+++ b/src/value/object.rs
@@ -1,5 +1,4 @@
 //! Represents a parsed JSON object.
-use core::hash;
 use std::{iter::FusedIterator, marker::PhantomData, slice};
 
 use faststr::FastStr;
@@ -433,7 +432,7 @@ impl Object {
         if let ValueMut::Object(o) = self.0.as_mut() {
             o.reserve(other.len());
             if let ValueMut::Object(oo) = other.0.as_mut() {
-                o.extend(oo.drain().into_iter());
+                o.extend(oo.drain());
             } else {
                 unreachable!("should not used in array")
             }
@@ -468,7 +467,7 @@ pub struct OccupiedEntry<'a> {
     _marker: PhantomData<&'a mut Pair>,
 }
 
-impl<'a, 'k> OccupiedEntry<'a> {
+impl<'a> OccupiedEntry<'a> {
     /// Gets a reference to the value in the entry.
     ///
     /// # Examples
@@ -584,8 +583,7 @@ impl<'a, 'k> OccupiedEntry<'a> {
     #[inline]
     pub fn remove(mut self) -> Value {
         let obj = unsafe { self.dormant_obj.reborrow() };
-        let val = obj.0.remove_key(self.key).unwrap();
-        val
+        obj.0.remove_key(self.key).unwrap()
     }
 
     #[inline]
@@ -889,6 +887,7 @@ impl_value_iter!((Values<'a>): &'a Value);
 
 /// A mutable iterator over the values of a `Object`.
 pub struct ValuesMut<'a>(IterMut<'a>);
+impl_value_iter!((ValuesMut<'a>): &'a mut Value);
 
 impl<'a> IntoIterator for &'a Object {
     type Item = (&'a str, &'a Value);

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -24,9 +24,9 @@ impl PartialEq for Value {
             ValueRefInner::Array(_) | ValueRefInner::EmptyArray => {
                 other.as_value_slice() == self.as_value_slice()
             }
-            ValueRefInner::Object(_) | ValueRefInner::EmptyObject => {
-                other.as_object() == self.as_object()
-            }
+            ValueRefInner::Object(_)
+            | ValueRefInner::EmptyObject
+            | ValueRefInner::ObjectOwned(_) => other.as_object() == self.as_object(),
         }
     }
 }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -224,7 +224,7 @@ impl serde::Serializer for Serializer {
         T: ?Sized + Serialize,
     {
         let mut object = Value::new_object_with(1);
-        object.insert(&variant, tri!(to_value(value)));
+        object.insert(variant, tri!(to_value(value)));
         Ok(object)
     }
 
@@ -414,7 +414,7 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
 
     fn end(self) -> Result<Value> {
         let mut object = Value::new_object_with(1);
-        object.insert(&self.static_name, self.vec);
+        object.insert(self.static_name, self.vec);
         Ok(object)
     }
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
perf: use hashmap in owned object to optimize search performance

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Sonic has a disadvantage compared to serde. Its object type search and insertion performance is O(n), which is determined by the underlying data structure.

To align performance to O(1), sonic objects also need to use hashmaps.

Specifically, sonic's data structures are divided into shared and owned. The former is used in the parse stage and has many internal optimizations. It is not suitable to directly replace the data structure for the time being.

The owned data structure can be directly replaced by hashmap for maintenance. At the same time, in order to support the sort keys function, btreemap is used to make performance tradeoffs for sorting and other operations.
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
