### PR TITLE
safety: check the node idx

### DIFF
--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -1574,6 +1574,7 @@ impl<'a> DocumentVisitor<'a> {
             // record the `Shared` pointer
             let meta = &mut *(hdr as *mut MetaNode);
             meta.shared = vis.shared as *const _;
+            meta.canary = transmute::<[u8; 8], u64>(*b"SONICRS\0");
 
             // update the container header
             let idx = (parent - vis.parent) as u32;

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -519,7 +519,6 @@ impl Drop for Value {
         if self.meta.get_kind() == Meta::STAIC_NODE || self.meta.in_shared() {
             return;
         }
-
         unsafe {
             match self.meta.get_type() {
                 Meta::FASTSTR | Meta::RAWNUM_FASTSTR => ManuallyDrop::drop(&mut self.data.str_own),
@@ -609,6 +608,7 @@ impl Value {
     }
 
     fn forward_find_shared(current: *const Value, idx: usize) -> *const Shared {
+        assert!(unsafe { (*(current.sub(idx) as *const MetaNode)).canary() });
         unsafe { (*(current.sub(idx) as *const MetaNode)).shared }
     }
 
@@ -1522,8 +1522,11 @@ impl MetaNode {
             canary: unsafe { transmute::<[u8; 8], u64>(*canary) },
         }
     }
+
+    fn canary(&self) -> bool {
+        self.canary == unsafe { std::mem::transmute::<[u8; 8], u64>(*b"SONICRS\0") }
+    }
 }
-// TODO: add assert for Value
 
 impl<'a> DocumentVisitor<'a> {
     fn visit_container_start(&mut self, kind: u64) -> bool {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
