### PR TITLE
feat: add sanitize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ use_raw = []
 
 # Allow to parse JSON with invalid UTF-8 and UTF-16 characters. Will replace them with `\uFFFD` (displayed as �).
 utf8_lossy = []
+
+# Enable sanitize, maybe cause 30% performance-loss in serialize.
+sanitize = []

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A fast Rust JSON library based on SIMD. It has some references to other open-sou
 
 3. Please add the compile options `-C target-cpu=native`
 
-4. Should enable `sanitize` feature if you are using LLVM-sanitizer in your program.
+4. Should enable `sanitize` feature to avoid false-positive if you are using LLVM-sanitizer in your program. Don't enable this feature in production, since it will cause 30% performance loss in serialize.
 
 ## Quick to use sonic-rs
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ A fast Rust JSON library based on SIMD. It has some references to other open-sou
 
 3. Please add the compile options `-C target-cpu=native`
 
+4. Should enable `sanitize` feature if you are using LLVM-sanitizer in your program.
+
 ## Quick to use sonic-rs
 
 To ensure that SIMD instruction is used in sonic-rs, you need to add rustflags `-C target-cpu=native` and compile on the host machine. For example, Rust flags can be configured in Cargo [config](.cargo/config.toml).

--- a/scripts/sanitize.sh
+++ b/scripts/sanitize.sh
@@ -5,11 +5,9 @@ set -ex
 export ASAN_OPTIONS="disable_coredump=0:unmap_shadow_on_exit=1:abort_on_error=1"
 
 run_tests() {
-    local san="$1"
-    local features="$2"
-    cargo +nightly test --target x86_64-unknown-linux-gnu --features "$features"  -- --test-threads=1 --nocapture
-    cargo +nightly test --doc --package sonic-rs --target x86_64-unknown-linux-gnu --features "$features" -- --show-output --test-threads=1
+    cargo +nightly test --release --target x86_64-unknown-linux-gnu --features sanitize "$2"
+    cargo +nightly test --doc --package sonic-rs --target x86_64-unknown-linux-gnu --features sanitize "$2"
 }
 
 echo "Running tests with $1 and $2"
-RUSTFLAGS="-Zsanitizer=$1" RUSTDOCFLAGS="-Zsanitizer=$1" run_tests $1 $2
+RUSTFLAGS="-Zsanitizer=$1" RUSTDOCFLAGS="-Zsanitizer=$1" run_tests "$2"

--- a/src/util/string.rs
+++ b/src/util/string.rs
@@ -585,12 +585,12 @@ pub fn format_string(value: &str, dst: &mut [MaybeUninit<u8>], need_quote: bool)
                 std::ptr::copy_nonoverlapping(sptr, temp[..].as_mut_ptr(), nb);
                 load(temp[..].as_ptr())
             } else {
-                #[cfg(not(debug_assertions))]
+                #[cfg(not(any(debug_assertions, feature = "sanitize")))]
                 {
                     // disable memory sanitizer here
                     load(sptr)
                 }
-                #[cfg(debug_assertions)]
+                #[cfg(any(debug_assertions, feature = "sanitize"))]
                 {
                     std::ptr::copy_nonoverlapping(sptr, temp[..].as_mut_ptr(), nb);
                     load(temp[..].as_ptr())


### PR DESCRIPTION
Add `sanitize` feature to avoid false-positive cases when using LLVM-sanitizer in release mode.

Note: we do not disable the `cross-page access` optimization in serialize because it may cause 30% performance-loss
```
     Running benches/serialize_struct.rs (target/release/deps/serialize_struct-0c18a33db440f245)
twitter/sonic_rs::to_string
                        time:   [399.60 µs 399.80 µs 400.02 µs]
                        change: [+32.975% +33.090% +33.201%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

canada/sonic_rs::to_string
                        time:   [3.3139 ms 3.3149 ms 3.3161 ms]
                        change: [-2.8470% -2.7749% -2.7149%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

citm_catalog/sonic_rs::to_string
                        time:   [698.99 µs 699.26 µs 699.57 µs]
                        change: [+27.642% +27.744% +27.834%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
```