### PR TITLE
chore: add ub notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: 'CI'
-on:
-  pull_request:
-  push:
+on: pull_request
 
 env:
   RUST_BACKTRACE: 1
@@ -56,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        san: [address, leak]
+        san: ["address,leak"]
         feature: ["", "arbitrary_precision", "sort_keys", "use_raw", "utf8_lossy"]
     name: Sanitize ${{matrix.san}} feature ${{matrix.feature}}
     runs-on: [self-hosted, Linux, amd64]

--- a/src/value/node.rs
+++ b/src/value/node.rs
@@ -67,8 +67,19 @@ use crate::{
 ///
 /// # Notes
 ///
-/// Actually the lookup in `Value` is O(n), not O(1). If you want to use `Value` as a map, recommend
-/// to use `serde_json::Value`.
+/// Not use any unsafe invalid_reference_casting for `Value`, it will cause UB.
+///
+/// ```rust,no_run
+/// use sonic_rs::{from_str, Value};
+/// let json = r#"["a", "b", "c"]"#;
+/// let root: Value = from_str(json).unwrap();
+/// let immref = &root["b"];
+///
+/// // This is dangerous, will coredump when using sanitizer
+/// #[allow(invalid_reference_casting)]
+/// let ub_cast = unsafe { &mut *(immref as *const _ as *mut Value) };
+/// let _ub = std::mem::take(ub_cast);
+/// ```
 #[repr(C)]
 pub struct Value {
     pub(crate) meta: Meta,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
