### PR TITLE
perf: Remove atomic

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -1,7 +1,7 @@
 //! Deserialize JSON data to a Rust data structure.
 
 // The code is cloned from [serde_json](https://github.com/serde-rs/json) and modified necessary parts.
-use std::{marker::PhantomData, mem::ManuallyDrop, ptr::slice_from_raw_parts, sync::Arc};
+use std::{marker::PhantomData, mem::ManuallyDrop, ptr::slice_from_raw_parts, rc::Rc};
 
 use serde::{
     de::{self, Expected, Unexpected},
@@ -29,7 +29,7 @@ pub struct Deserializer<R> {
     pub(crate) parser: Parser<R>,
     scratch: Vec<u8>,
     remaining_depth: u8,
-    shared: Option<Arc<Shared>>, // the shared allocator for `Value`
+    shared: Option<Rc<Shared>>, // the shared allocator for `Value`
 }
 
 // some functions only used for struct visitors.
@@ -389,10 +389,10 @@ impl<'de, R: Reader<'de>> Deserializer<R> {
         } else {
             let shared = unsafe {
                 if self.shared.is_none() {
-                    self.shared = Some(Arc::new(Shared::default()));
+                    self.shared = Some(Rc::new(Shared::default()));
                 }
                 let shared = self.shared.as_mut().unwrap();
-                &mut *(Arc::as_ptr(shared) as *mut _)
+                &mut *(Rc::as_ptr(shared) as *mut _)
             };
             // deserialize some json parts into `Value`, not use padding buffer, avoid the memory
             // copy


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
perf

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
去除原子

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
Before:
```
twitter/sonic_rs::from_slice_unchecked
                        time:   [363.26 µs 363.53 µs 363.84 µs]
twitter/sonic_rs::from_slice
                        time:   [386.96 µs 387.34 µs 387.74 µs]
twitter/simd_json::from_slice
                        time:   [493.21 µs 493.61 µs 494.07 µs]
twitter/serde_json::from_slice
                        time:   [1.1023 ms 1.1028 ms 1.1034 ms]
twitter/serde_json::from_str
                        time:   [545.09 µs 545.39 µs 545.76 µs]

citm_catalog/sonic_rs::from_slice_unchecked
                        time:   [629.17 µs 629.67 µs 630.23 µs]
citm_catalog/sonic_rs::from_slice
                        time:   [662.14 µs 662.77 µs 663.50 µs]
citm_catalog/simd_json::from_slice
                        time:   [991.69 µs 992.57 µs 993.58 µs]
citm_catalog/serde_json::from_slice
                        time:   [1.5687 ms 1.5703 ms 1.5719 ms]
citm_catalog/serde_json::from_str
                        time:   [1.2268 ms 1.2275 ms 1.2283 ms]

canada/sonic_rs::from_slice_unchecked
                        time:   [2.4722 ms 2.4735 ms 2.4749 ms]
canada/sonic_rs::from_slice
                        time:   [2.5169 ms 2.5185 ms 2.5201 ms]
canada/simd_json::from_slice
                        time:   [3.1946 ms 3.2023 ms 3.2095 ms]
canada/serde_json::from_slice
                        time:   [5.2201 ms 5.2222 ms 5.2248 ms]
canada/serde_json::from_str
                        time:   [5.2140 ms 5.2157 ms 5.2176 ms]

```
After:
```
twitter/sonic_rs::from_slice_unchecked
                        time:   [361.38 µs 361.76 µs 362.30 µs]
twitter/sonic_rs::from_slice
                        time:   [383.33 µs 383.66 µs 384.06 µs]
twitter/simd_json::from_slice
                        time:   [498.60 µs 499.27 µs 500.03 µs]
twitter/serde_json::from_slice
                        time:   [1.0513 ms 1.0518 ms 1.0525 ms]
twitter/serde_json::from_str
                        time:   [534.71 µs 535.03 µs 535.44 µs]

citm_catalog/sonic_rs::from_slice_unchecked
                        time:   [635.39 µs 635.82 µs 636.41 µs]
citm_catalog/sonic_rs::from_slice
                        time:   [667.54 µs 667.97 µs 668.44 µs]
citm_catalog/simd_json::from_slice
                        time:   [981.67 µs 982.59 µs 983.68 µs]
citm_catalog/serde_json::from_slice
                        time:   [1.4641 ms 1.4650 ms 1.4660 ms]
citm_catalog/serde_json::from_str
                        time:   [1.2239 ms 1.2245 ms 1.2252 ms]

canada/sonic_rs::from_slice_unchecked
                        time:   [2.4682 ms 2.4696 ms 2.4712 ms]
canada/sonic_rs::from_slice
                        time:   [2.5145 ms 2.5160 ms 2.5176 ms]
canada/simd_json::from_slice
                        time:   [3.2294 ms 3.2321 ms 3.2350 ms]
canada/serde_json::from_slice
                        time:   [5.2210 ms 5.2229 ms 5.2250 ms]
canada/serde_json::from_str
                        time:   [5.2229 ms 5.2240 ms 5.2253 ms]

```

Looks similar but I don't think we need the atomic.

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
