### PR TITLE
perf: Switch from `ryu` -> `zmij` for float formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if       = "1.0"
 faststr      = { version = "0.2", features = ["serde"] }
 itoa         = "1.0"
 ref-cast     = "1.0"
-ryu          = "1.0"
+zmij         = "0.1"
 serde        = { version = "1.0", features = ["rc", "derive"] }
 simdutf8     = "0.1"
 sonic-number = { path = "./sonic-number", version = "0.1" }

--- a/src/format.rs
+++ b/src/format.rs
@@ -152,7 +152,7 @@ pub trait Formatter: Clone {
             return self.write_i64(writer, value as i64);
         }
 
-        let mut buffer = ryu::Buffer::new();
+        let mut buffer = zmij::Buffer::new();
         let s = buffer.format_finite(value);
         writer.write_all(s.as_bytes())
     }
@@ -168,7 +168,7 @@ pub trait Formatter: Clone {
             return self.write_i64(writer, value as i64);
         }
 
-        let mut buffer = ryu::Buffer::new();
+        let mut buffer = zmij::Buffer::new();
         let s = buffer.format_finite(value);
         writer.write_all(s.as_bytes())
     }

--- a/src/serde/number.rs
+++ b/src/serde/number.rs
@@ -175,7 +175,7 @@ impl Display for Number {
         match self.n {
             N::PosInt(u) => formatter.write_str(itoa::Buffer::new().format(u)),
             N::NegInt(i) => formatter.write_str(itoa::Buffer::new().format(i)),
-            N::Float(f) => formatter.write_str(ryu::Buffer::new().format_finite(f)),
+            N::Float(f) => formatter.write_str(zmij::Buffer::new().format_finite(f)),
         }
     }
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -977,7 +977,7 @@ impl serde::Serializer for SortedKeySerializer {
 
     fn serialize_f32(self, value: f32) -> Result<String> {
         if value.is_finite() {
-            let mut buf = ryu::Buffer::new();
+            let mut buf = zmij::Buffer::new();
             Ok(buf.format_finite(value).to_owned())
         } else {
             Err(key_must_be_str_or_num(Unexpected::Other(
@@ -988,7 +988,7 @@ impl serde::Serializer for SortedKeySerializer {
 
     fn serialize_f64(self, value: f64) -> Result<String> {
         if value.is_finite() {
-            let mut buf = ryu::Buffer::new();
+            let mut buf = zmij::Buffer::new();
             Ok(buf.format_finite(value).to_owned())
         } else {
             Err(key_must_be_str_or_num(Unexpected::Other(

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -537,7 +537,7 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f32(self, value: f32) -> Result<Value> {
         if value.is_finite() {
-            self.serialize_str(ryu::Buffer::new().format_finite(value))
+            self.serialize_str(zmij::Buffer::new().format_finite(value))
         } else {
             Err(float_key_must_be_finite())
         }
@@ -545,7 +545,7 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f64(self, value: f64) -> Result<Value> {
         if value.is_finite() {
-            self.serialize_str(ryu::Buffer::new().format_finite(value))
+            self.serialize_str(zmij::Buffer::new().format_finite(value))
         } else {
             Err(float_key_must_be_finite())
         }


### PR DESCRIPTION
#### What type of PR is this?

Prior art: [`serde_json` switch to `zmij`](https://github.com/serde-rs/json/pull/1304).

###### Benchmarks:

Before: 

`cargo bench --bench serialize_value  -- --quiet`

```
twitter/sonic_rs::to_string
                        time:   [169.35 µs 171.97 µs 175.03 µs]
twitter/sonic_rs::to_string_use_rawnum
                        time:   [165.90 µs 166.70 µs 167.51 µs]
twitter/serde_json::to_string
                        time:   [264.41 µs 266.75 µs 270.01 µs]
twitter/simd_json::to_string
                        time:   [373.62 µs 375.00 µs 376.67 µs]

citm_catalog/sonic_rs::to_string
                        time:   [360.41 µs 361.24 µs 362.07 µs]
citm_catalog/sonic_rs::to_string_use_rawnum
                        time:   [335.28 µs 335.75 µs 336.34 µs]
citm_catalog/serde_json::to_string
                        time:   [354.97 µs 355.44 µs 355.93 µs]
citm_catalog/simd_json::to_string
                        time:   [595.46 µs 597.73 µs 600.29 µs]

canada/sonic_rs::to_string
                        time:   [2.3048 ms 2.3071 ms 2.3096 ms]
canada/sonic_rs::to_string_use_rawnum
                        time:   [900.75 µs 904.56 µs 908.61 µs]
canada/serde_json::to_string
                        time:   [2.3718 ms 2.3761 ms 2.3808 ms]
canada/simd_json::to_string
                        time:   [2.9103 ms 2.9259 ms 2.9432 ms]
```

After:

`cargo bench --bench serialize_value  -- --quiet`

```
twitter/sonic_rs::to_string
                        time:   [157.88 µs 158.09 µs 158.29 µs]
twitter/sonic_rs::to_string_use_rawnum
                        time:   [154.21 µs 154.39 µs 154.58 µs]
twitter/serde_json::to_string
                        time:   [262.33 µs 262.63 µs 263.01 µs]
twitter/simd_json::to_string
                        time:   [366.31 µs 367.47 µs 368.78 µs]

citm_catalog/sonic_rs::to_string
                        time:   [348.75 µs 349.64 µs 350.52 µs]
citm_catalog/sonic_rs::to_string_use_rawnum
                        time:   [321.57 µs 322.08 µs 322.61 µs]
citm_catalog/serde_json::to_string
                        time:   [343.72 µs 344.04 µs 344.38 µs]
citm_catalog/simd_json::to_string
                        time:   [585.01 µs 587.35 µs 589.85 µs]

canada/sonic_rs::to_string
                        time:   [2.0157 ms 2.0189 ms 2.0223 ms]
canada/sonic_rs::to_string_use_rawnum
                        time:   [811.51 µs 818.01 µs 824.70 µs]
canada/serde_json::to_string
                        time:   [2.2198 ms 2.2226 ms 2.2255 ms]
canada/simd_json::to_string
                        time:   [2.9320 ms 2.9448 ms 2.9605 ms]
```

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
