### PR TITLE
ci: use GitHub-hosted ARM runner for aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         matrix:
             os:
               - [self-hosted, Linux, amd64]
-              - [self-hosted, Linux, aarch64]
+              - ubuntu-24.04-arm
     name: Rust stable
     runs-on: ${{matrix.os}}
     timeout-minutes: 45
@@ -47,7 +47,7 @@ jobs:
       matrix:
         os:
           - [self-hosted, Linux, amd64]
-          - [self-hosted, Linux, aarch64]
+          - ubuntu-24.04-arm
     name: Rust nightly
     runs-on: ${{matrix.os}}
     timeout-minutes: 45


### PR DESCRIPTION
- Replace self-hosted `[self-hosted, Linux, aarch64]` with official runner `ubuntu-24.04-arm` in `test-stable-hosted` and `test-nightly-hosted`.
- ARM jobs now run on GitHub-hosted Ubuntu 24.04 ARM64 runners (free for public repos in public preview).