### PR TITLE
feat: support wasm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,9 @@ rustflags    = ["-g", "-C", "target-cpu=native"]
 [bench]
 rustdocflags = ["-C", "target-cpu=native"]
 rustflags    = ["-g", "-C", "target-cpu=native"]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+simd128"]
+
+[target.wasm32-wasi]
+rustflags = ["-C", "target-feature=+simd128"]

--- a/sonic-simd/README.md
+++ b/sonic-simd/README.md
@@ -1,8 +1,9 @@
 
 # sonic_simd
 
-A portable SIMD library that provides low-level APIs for x86, ARM. Other platforms will use the fallback scalar implementation.
+A portable SIMD library that provides low-level APIs for x86, ARM, wasm. Other platforms will use the fallback scalar implementation.
 
 TODO:
 
-1. support RISC-V.
+- [x] support WASM.
+- [ ] support RISC-V.

--- a/sonic-simd/src/lib.rs
+++ b/sonic-simd/src/lib.rs
@@ -11,8 +11,10 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
         pub mod neon;
         use self::neon::*;
+    } else if #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))] {
+        mod wasm128;
+        use self::wasm128::*;
     } else {
-        // TODO: support wasm
         mod v128;
         use self::v128::*;
     }

--- a/sonic-simd/src/wasm128.rs
+++ b/sonic-simd/src/wasm128.rs
@@ -1,0 +1,135 @@
+use std::{
+    arch::wasm32::*,
+    ops::{BitAnd, BitOr, BitOrAssign},
+};
+
+use super::{Mask, Simd};
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Simd128i(v128);
+
+impl Simd for Simd128i {
+    const LANES: usize = 16;
+
+    type Element = i8;
+
+    type Mask = Mask128;
+
+    #[inline(always)]
+    unsafe fn loadu(ptr: *const u8) -> Self {
+        Self(v128_load(ptr as _))
+    }
+
+    #[inline(always)]
+    unsafe fn storeu(&self, ptr: *mut u8) {
+        v128_store(ptr as _, self.0);
+    }
+
+    #[inline(always)]
+    fn eq(&self, rhs: &Self) -> Self::Mask {
+        Mask128(i8x16_eq(self.0, rhs.0))
+    }
+
+    #[inline(always)]
+    fn splat(elem: Self::Element) -> Self {
+        Self(i8x16_splat(elem))
+    }
+
+    #[inline(always)]
+    fn gt(&self, rhs: &Self) -> Self::Mask {
+        Mask128(i8x16_gt(self.0, rhs.0))
+    }
+
+    #[inline(always)]
+    fn le(&self, rhs: &Self) -> Self::Mask {
+        Mask128(i8x16_le(self.0, rhs.0))
+    }
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Simd128u(v128);
+
+impl Simd for Simd128u {
+    const LANES: usize = 16;
+
+    type Element = u8;
+
+    type Mask = Mask128;
+
+    #[inline(always)]
+    unsafe fn loadu(ptr: *const u8) -> Self {
+        Self(v128_load(ptr as _))
+    }
+
+    #[inline(always)]
+    unsafe fn storeu(&self, ptr: *mut u8) {
+        v128_store(ptr as _, self.0);
+    }
+
+    #[inline(always)]
+    fn eq(&self, rhs: &Self) -> Self::Mask {
+        Mask128(i8x16_eq(self.0, rhs.0))
+    }
+
+    #[inline(always)]
+    fn splat(elem: Self::Element) -> Self {
+        Self(u8x16_splat(elem))
+    }
+
+    #[inline(always)]
+    fn gt(&self, rhs: &Self) -> Self::Mask {
+        Mask128(u8x16_gt(self.0, rhs.0))
+    }
+
+    #[inline(always)]
+    fn le(&self, rhs: &Self) -> Self::Mask {
+        Mask128(u8x16_le(self.0, rhs.0))
+    }
+}
+
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Mask128(v128);
+
+impl Mask for Mask128 {
+    type Element = u8;
+
+    type BitMask = u16;
+
+    #[inline(always)]
+    fn bitmask(self) -> Self::BitMask {
+        i8x16_bitmask(self.0)
+    }
+
+    #[inline(always)]
+    fn splat(b: bool) -> Self {
+        Self(i8x16_splat(if b { -1 } else { 0 }))
+    }
+}
+
+impl BitAnd for Mask128 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self(v128_and(self.0, rhs.0))
+    }
+}
+
+impl BitOr for Mask128 {
+    type Output = Self;
+
+    #[inline(always)]
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(v128_or(self.0, rhs.0))
+    }
+}
+
+impl BitOrAssign for Mask128 {
+    #[inline(always)]
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 = v128_or(self.0, rhs.0)
+    }
+}


### PR DESCRIPTION
#### What type of PR is this?

feat: support wasm128
perf: A code change that improves performance

#### Which issue(s) this PR fixes:

fix https://github.com/cloudwego/sonic-rs/issues/70

#### The PR that updates user documentation:

updated documentation of sonic-simd

#### test

1. install `wasmtime`
2. test the examples by  by `wasmtime run --dir . target/wasm32-wasip1/release/examples/*.wasm` (since the `serde` example needs to read file)

#### perf

##### Steps

1. download this [gist](https://gist.github.com/hsqStephenZhang/17f1c950e9be20d838a468d955fd0f0e) and put into example dir
3. compile via `cargo build --examples --target wasm32-wasip1 --release` add `RUSTFLAGS="-C target-feature=+simd128"`
4. `wasmtime run target/wasm32-wasip1/release/examples/serde.wasm`
5. add `RUSTFLAGS="-C target-feature=+simd128" and repeat the 2-3, compare the results.

##### Result on my local machine

before:

```bash
=== sonic-rs wasm benchmark ===
SIMD mode: fallback (scalar)
JSON payload size: 2955 bytes

[parse_to_value]  10000 iters, 10953 ns/op, 257.3 MB/s
[get_from x3]     10000 iters, 32398 ns/op
[serialize]       10000 iters, 11668 ns/op, 241.5 MB/s
```

after:

```bash
=== sonic-rs wasm benchmark ===
SIMD mode: wasm-simd128
JSON payload size: 2955 bytes

[parse_to_value]  10000 iters, 5038 ns/op, 559.4 MB/s
[get_from x3]     10000 iters, 11433 ns/op
[serialize]       10000 iters, 3110 ns/op, 906.3 MB/s
```

#### TODOs

- [ ] add wasmtime test to CI?
