### PR TITLE
feat: add LazyValue::as_cow_str

### DIFF
--- a/src/lazyvalue/value.rs
+++ b/src/lazyvalue/value.rs
@@ -338,6 +338,36 @@ impl<'a> JsonValueTrait for LazyValue<'a> {
 }
 
 impl<'a> LazyValue<'a> {
+    /// Returns `Cow<'de, str>` if `self` is a `string`. The lifetime `'de` is the origin JSON.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sonic_rs::LazyValue;
+    ///
+    /// let lv: LazyValue = sonic_rs::get(r#"{"a": "hello world"}"#, &["a"]).unwrap();
+    /// assert_eq!(lv.as_cow_str().unwrap(), "hello world");
+    /// ```
+    pub fn as_cow_str(&self) -> Option<Cow<'a, str>> {
+        if !self.is_str() {
+            return None;
+        }
+
+        if self.inner.no_escaped() {
+            // remove the quotes
+            Some(match &self.raw {
+                JsonSlice::Raw(r) => {
+                    Cow::Borrowed(unsafe { from_utf8_unchecked(&r[1..r.len() - 1]) })
+                }
+                JsonSlice::FastStr(f) => Cow::Owned(f[1..f.len() - 1].to_string()),
+            })
+        } else {
+            self.inner
+                .parse_from(self.raw.as_ref())
+                .map(|s| Cow::Owned(s.into()))
+        }
+    }
+
     /// Export the raw JSON text as `str`.
     ///
     /// # Examples
@@ -355,12 +385,12 @@ impl<'a> LazyValue<'a> {
         unsafe { from_utf8_unchecked(self.raw.as_ref()) }
     }
 
-    /// Export the raw JSON text as `Cow<'de, str>`.  The lifetime `'de` is the origin JSON.
+    /// Export the raw JSON text as `Cow<'de, str>`. The lifetime `'de` is the origin JSON.
     ///
     /// # Examples
     ///
     /// ```
-    /// use sonic_rs::{get, LazyValue};
+    /// use sonic_rs::LazyValue;
     ///
     /// let lv: LazyValue = sonic_rs::get(r#"{"a": "hello world"}"#, &["a"]).unwrap();
     /// assert_eq!(lv.as_raw_cow(), "\"hello world\"");


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### More detailed description for this PR.
Add LazyValue::as_cow_str to support zero-copy get.

Currently, `sonic-rs::get` returns `LazyValue`, but `LazyValue::as_str` returns `&str` which is tied to the lifetime of the `LazyValue` reference instead of the input. This means that even if there are no escapes, we've to copy the str to return the value. `LazyValue::as_cow_str` returns a `Cow<'a, str>` which is tied to the lifetime of the input.